### PR TITLE
fix: misc improvements in shopify integration

### DIFF
--- a/ecommerce_integrations/config/desktop.py
+++ b/ecommerce_integrations/config/desktop.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from frappe import _
 
 def get_data():

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
@@ -25,6 +25,8 @@
   {
    "fieldname": "integration",
    "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Integration",
    "options": "Module Def"
   },
@@ -68,7 +70,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-04-15 15:21:03.437302",
+ "modified": "2021-05-28 16:06:49.008875",
  "modified_by": "Administrator",
  "module": "Ecommerce Integrations",
  "name": "Ecommerce Integration Log",

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -11,7 +11,6 @@ from frappe.utils import strip_html
 
 
 class EcommerceIntegrationLog(Document):
-
 	def validate(self):
 		self._set_title()
 

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log_list.js
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log_list.js
@@ -1,4 +1,5 @@
 frappe.listview_settings["Ecommerce Integration Log"] = {
+	hide_name_column: true,
 	add_fields: ["status"],
 	get_indicator: function(doc) {
 		if(doc.status==="Success"){

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/test_ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/test_ecommerce_integration_log.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.json
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.json
@@ -5,13 +5,14 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "erpnext_item_code",
   "integration",
+  "erpnext_item_code",
   "integration_item_code",
+  "sku",
+  "column_break_5",
   "has_variants",
   "variant_id",
   "variant_of",
-  "sku",
   "inventory_synced_on"
  ],
  "fields": [
@@ -19,58 +20,76 @@
    "fieldname": "erpnext_item_code",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "ERPNext Item Code",
    "options": "Item",
-   "reqd": 1
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "integration",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Integration",
    "options": "Module Def",
-   "reqd": 1
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "integration_item_code",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Integration Item Code",
-   "reqd": 1
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "variant_id",
    "fieldtype": "Data",
-   "label": "Variant ID"
+   "label": "Variant ID",
+   "read_only": 1
   },
   {
    "default": "0",
    "fieldname": "has_variants",
    "fieldtype": "Check",
-   "label": "Has Variants"
+   "label": "Has Variants",
+   "read_only": 1
   },
   {
    "description": "ERPNext template Item ID",
    "fieldname": "variant_of",
    "fieldtype": "Link",
    "label": "Variant Of",
-   "options": "Item"
+   "options": "Item",
+   "read_only": 1
   },
   {
    "fieldname": "sku",
    "fieldtype": "Data",
-   "label": "SKU"
+   "label": "SKU",
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "inventory_synced_on",
    "fieldtype": "Datetime",
    "label": "Inventory Synced On",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_5",
+   "fieldtype": "Column Break"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-05 15:11:56.588071",
+ "modified": "2021-05-28 16:23:08.839942",
  "modified_by": "Administrator",
  "module": "Ecommerce Integrations",
  "name": "Ecommerce Item",

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -138,7 +138,7 @@ def create_ecommerce_item(
 	item.update(item_dict)
 
 	new_item = frappe.get_doc(item)
-	frappe.flags.creating_ecommerce_item = True
+	new_item.flags.from_integration = True
 	new_item.insert(ignore_permissions=True, ignore_mandatory=True)
 
 	# SKU not allowed for template items
@@ -159,5 +159,4 @@ def create_ecommerce_item(
 
 	ecommerce_item.insert()
 
-	frappe.flags.creating_ecommerce_item = False
 	frappe.db.commit()

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item_list.js
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item_list.js
@@ -1,0 +1,3 @@
+frappe.listview_settings["Ecommerce Item"] = {
+	hide_name_column: true,
+}

--- a/ecommerce_integrations/shopify/connection.py
+++ b/ecommerce_integrations/shopify/connection.py
@@ -54,15 +54,15 @@ def register_webhooks(shopify_url: str, password: str) -> List[Webhook]:
 	return new_webhooks
 
 
-@temp_shopify_session
-def unregister_webhooks() -> None:
+def unregister_webhooks(shopify_url: str, password: str) -> None:
 	"""Unregister all webhooks from shopify that correspond to current site url."""
-
 	callback_url = get_callback_url()
 
-	for webhook in Webhook.find():
-		if webhook.address == callback_url:
-			webhook.destroy()
+	with Session.temp(shopify_url, API_VERSION, password):
+
+		for webhook in Webhook.find():
+			if webhook.address == callback_url:
+				webhook.destroy()
 
 
 def get_current_domain_name() -> str:

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -51,7 +51,7 @@ class ShopifySetting(SettingController):
 				self.append("webhooks", {"webhook_id": webhook.id, "method": webhook.topic})
 
 		elif not self.is_enabled():
-			connection.unregister_webhooks()
+			connection.unregister_webhooks(self.shopify_url, self.get_password("password"))
 
 			self.webhooks = list()  # remove all webhooks
 

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -43,8 +43,8 @@ class ShopifySetting(SettingController):
 				new_webhooks = []
 
 			if not new_webhooks:
-				msg = _("Failed to register webhooks with Shopify.")
-				msg += _("Please check credentials and retry.")
+				msg = _("Failed to register webhooks with Shopify.") + "<br>"
+				msg += _("Please check credentials and retry. Disabling and re-enabling the integration might also help.")
 				frappe.throw(msg)
 
 			for webhook in new_webhooks:

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -9,7 +9,10 @@ from shopify.resources import Location
 
 from ecommerce_integrations.controllers.setting import SettingController
 from ecommerce_integrations.shopify import connection
-from ecommerce_integrations.shopify.utils import migrate_from_old_connector, ensure_old_connector_is_disabled
+from ecommerce_integrations.shopify.utils import (
+	migrate_from_old_connector,
+	ensure_old_connector_is_disabled,
+)
 from ecommerce_integrations.shopify.constants import (
 	ADDRESS_ID_FIELD,
 	CUSTOMER_ID_FIELD,
@@ -28,14 +31,15 @@ class ShopifySetting(SettingController):
 	def validate(self):
 		ensure_old_connector_is_disabled()
 
-		if not self.is_old_data_migrated:
-			migrate_from_old_connector()
-
 		self._handle_webhooks()
 		self._validate_warehouse_links()
 
 		if self.is_enabled():
 			setup_custom_fields()
+
+	def on_update(self):
+		if not self.is_old_data_migrated:
+			migrate_from_old_connector()
 
 	def _handle_webhooks(self):
 		if self.is_enabled() and not self.webhooks:

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -9,7 +9,7 @@ from shopify.resources import Location
 
 from ecommerce_integrations.controllers.setting import SettingController
 from ecommerce_integrations.shopify import connection
-from ecommerce_integrations.shopify.utils import migrate_from_old_connector
+from ecommerce_integrations.shopify.utils import migrate_from_old_connector, ensure_old_connector_is_disabled
 from ecommerce_integrations.shopify.constants import (
 	ADDRESS_ID_FIELD,
 	CUSTOMER_ID_FIELD,
@@ -26,6 +26,8 @@ class ShopifySetting(SettingController):
 		return bool(self.enable_shopify)
 
 	def validate(self):
+		ensure_old_connector_is_disabled()
+
 		if not self.is_old_data_migrated:
 			migrate_from_old_connector()
 

--- a/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 

--- a/ecommerce_integrations/shopify/inventory.py
+++ b/ecommerce_integrations/shopify/inventory.py
@@ -42,7 +42,7 @@ def upload_inventory_data_to_shopify(inventory_levels, warehous_map) -> None:
 			result = InventoryLevel.set(
 				location_id=d.shopify_location_id,
 				inventory_item_id=inventory_id,
-				available=cint(d.actual_qty),  # shopify doesn't support fractional quantity
+				available=cint(d.actual_qty) - cint(d.reserved_qty),  # shopify doesn't support fractional quantity
 			)
 			frappe.db.set_value("Ecommerce Item", d.ecom_item, "inventory_synced_on", synced_on)
 			d.status = "Success"
@@ -68,7 +68,7 @@ def _get_inventory_levels(warehouses: Tuple[str]) -> List[_dict]:
 	"""
 	data = frappe.db.sql(
 		f"""
-			SELECT ei.name as ecom_item, bin.item_code as item_code, variant_id, actual_qty, warehouse
+			SELECT ei.name as ecom_item, bin.item_code as item_code, variant_id, actual_qty, warehouse, reserved_qty
 			FROM `tabEcommerce Item` ei
 				JOIN tabBin bin
 				ON ei.erpnext_item_code = bin.item_code

--- a/ecommerce_integrations/shopify/inventory.py
+++ b/ecommerce_integrations/shopify/inventory.py
@@ -42,7 +42,7 @@ def upload_inventory_data_to_shopify(inventory_levels, warehous_map) -> None:
 			result = InventoryLevel.set(
 				location_id=d.shopify_location_id,
 				inventory_item_id=inventory_id,
-				available=cint(d.actual_qty),  # shopify doesn't support fractional quantity TODO: docs
+				available=cint(d.actual_qty),  # shopify doesn't support fractional quantity
 			)
 			frappe.db.set_value("Ecommerce Item", d.ecom_item, "inventory_synced_on", synced_on)
 			d.status = "Success"

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -286,7 +286,6 @@ def sync_old_orders():
 			)
 			sync_sales_order(order, request_id=log.name)
 
-
 		shopify_setting = frappe.get_doc(SETTING_DOCTYPE)
 		shopify_setting.sync_old_orders = 0
 		shopify_setting.save()

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -318,14 +318,15 @@ def upload_erpnext_item(doc, method=None):
 	updated depending on what is configured in "Shopify Setting" doctype.
 	"""
 	item = doc  # alias for readability
+	# a new item recieved from ecommerce_integrations is being inserted
+	if item.flags.from_integration:
+		return
+
 	setting = frappe.get_doc(SETTING_DOCTYPE)
 
 	if not setting.is_enabled() or not setting.upload_erpnext_items:
 		return
 
-	# a new item recieved from ecommerce_integrations is being inserted
-	if frappe.flags.creating_ecommerce_item:
-		return
 
 	if frappe.flags.in_import:
 		return

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -391,6 +391,11 @@ def map_erpnext_item_to_shopify(shopify_product: Product, erpnext_item):
 		shopify_product.weight = erpnext_item.weight_per_unit
 		shopify_product.weight_unit = uom
 
+	if erpnext_item.disabled:
+		shopify_product.status = "draft"
+		shopify_product.published = False
+		msgprint(_("Status of linked Shopify product is changed to Draft."))
+
 
 def get_shopify_weight_uom(erpnext_weight_uom: str) -> str:
 	for shopify_uom, erpnext_uom in WEIGHT_TO_ERPNEXT_UOM_MAP.items():
@@ -403,7 +408,7 @@ def update_default_variant_properties(
 	is_stock_item: bool,
 	sku: Optional[str] = None,
 	price: Optional[float] = None,
-) -> Product:
+):
 	"""Shopify creates default variant upon saving the product.
 
 	Some item properties are supposed to be updated on the default variant.
@@ -420,7 +425,6 @@ def update_default_variant_properties(
 	if sku is not None:
 		default_variant.sku = sku
 
-	return shopify_product
 
 
 def write_upload_log(status: bool, product: Product, item, action="Created") -> None:

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -427,7 +427,6 @@ def update_default_variant_properties(
 		default_variant.sku = sku
 
 
-
 def write_upload_log(status: bool, product: Product, item, action="Created") -> None:
 	if not status:
 		msg = _("Failed to upload item to Shopify") + "<br>"

--- a/ecommerce_integrations/shopify/tests/utils.py
+++ b/ecommerce_integrations/shopify/tests/utils.py
@@ -7,7 +7,7 @@ import shopify
 from pyactiveresource.activeresource import ActiveResource
 from pyactiveresource.testing import http_fake
 
-from ecommerce_integrations.shopify.constants import API_VERSION
+from ecommerce_integrations.shopify.constants import API_VERSION, SETTING_DOCTYPE
 
 
 # Following code is adapted from Shopify python api under MIT license with minor changes.
@@ -37,7 +37,7 @@ from ecommerce_integrations.shopify.constants import API_VERSION
 class TestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
-		setting = frappe.get_doc("Shopify Settings")
+		setting = frappe.get_doc(SETTING_DOCTYPE)
 
 		setting.update({"shopify_url": "frappetest.myshopify.com",}).save(ignore_permissions=True)
 

--- a/ecommerce_integrations/shopify/utils.py
+++ b/ecommerce_integrations/shopify/utils.py
@@ -22,8 +22,6 @@ def create_shopify_log(**kwargs):
 def migrate_from_old_connector(payload=None, request_id=None):
 	"""This function is called to migrate data from old connector to new connector."""
 
-	_check_old_connector_status()
-
 	if request_id:
 		log = frappe.get_doc("Ecommerce Integration Log", request_id)
 	else:
@@ -36,7 +34,7 @@ def migrate_from_old_connector(payload=None, request_id=None):
 	)
 
 
-def _check_old_connector_status():
+def ensure_old_connector_is_disabled():
 	old_setting = frappe.get_doc(OLD_SETTINGS_DOCTYPE)
 
 	if old_setting.enable_shopify:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:


### PR DESCRIPTION
- [x] Convert shopify product to draft when disabling erpnext item
- [x] While updating inventory subtract reserved qty (to better reflect Shopify's inventory tracking method)
- [x] Better title for ecommerce integration log
- [x] Ecommerce item and log page UX cleanup
- [x] Eliminate use of global flags for locking
- [x] fix: old data migration check happening multiple times.
- [ ] [deferred] Cleanup setting page and improve UX. Add proper descriptions. Group default fields.
- [ ] [deferred] Add ability to sync items on per-item basis. 
- [ ] [deferred] Improve handling of timezones while syncing old orders by time.
- [ ] [deferred] Improve error messages, highlight typical issues while setting up connector.


+ minor code cleanups.