### PR TITLE
fix: don't try to create session if not configured

### DIFF
--- a/ecommerce_integrations/shopify/connection.py
+++ b/ecommerce_integrations/shopify/connection.py
@@ -28,10 +28,11 @@ def temp_shopify_session(func):
 			return func(*args, **kwargs)
 
 		setting = frappe.get_doc(SETTING_DOCTYPE)
-		auth_details = (setting.shopify_url, API_VERSION, setting.get_password("password"))
+		if setting.is_enabled():
+			auth_details = (setting.shopify_url, API_VERSION, setting.get_password("password"))
 
-		with Session.temp(*auth_details):
-			return func(*args, **kwargs)
+			with Session.temp(*auth_details):
+				return func(*args, **kwargs)
 
 	return wrapper
 


### PR DESCRIPTION
When app is not configured and decorator attempts to create a session and it tries to get the password field. This causes the user to log out.

fixes #9 