### PR TITLE
feat: Enable a description text for the final invoice on each tax line setting (#13)

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.json
+++ b/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.json
@@ -6,7 +6,8 @@
  "field_order": [
   "shopify_tax",
   "column_break_2",
-  "tax_account"
+  "tax_account",
+  "tax_description"
  ],
  "fields": [
   {
@@ -27,11 +28,18 @@
    "label": "ERPNext Account",
    "options": "Account",
    "reqd": 1
+  },
+  {
+   "fieldname": "tax_description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Tax Description",
+   "translatable": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-05-10 19:58:50.368785",
+ "modified": "2021-06-05 10:52:18.427400",
  "modified_by": "Administrator",
  "module": "shopify",
  "name": "Shopify Tax Account",

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -157,7 +157,7 @@ def get_order_taxes(shopify_order, setting):
 			{
 				"charge_type": _("On Net Total"),
 				"account_head": get_tax_account_head(tax),
-				"description": f"{tax.get('title')} - {tax.get('rate') * 100.0}%",
+				"description": f"{get_tax_account_description(tax,tax.get('title'))} - {tax.get('rate') * 100.0}%",
 				"rate": tax.get("rate") * 100.00,
 				"included_in_print_rate": 1 if shopify_order.get("taxes_included") else 0,
 				"cost_center": setting.cost_center,
@@ -180,6 +180,18 @@ def get_tax_account_head(tax):
 		frappe.throw(_("Tax Account not specified for Shopify Tax {0}").format(tax.get("title")))
 
 	return tax_account
+
+def get_tax_account_description(tax, fallback):
+	tax_title = tax.get("title").encode("utf-8")
+
+	tax_description = frappe.db.get_value(
+		"Shopify Tax Account", {"parent": SETTING_DOCTYPE, "shopify_tax": tax_title}, "tax_description",
+	)
+
+	if not tax_description:
+		tax_description = fallback;
+
+	return tax_description
 
 
 def get_discounted_amount(order):

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -157,7 +157,7 @@ def get_order_taxes(shopify_order, setting):
 			{
 				"charge_type": _("On Net Total"),
 				"account_head": get_tax_account_head(tax),
-				"description": f"{get_tax_account_description(tax,tax.get('title'))} - {tax.get('rate') * 100.0}%",
+				"description": f"{get_tax_account_description(tax) or tax.get('title')} - {tax.get('rate') * 100.0}%",
 				"rate": tax.get("rate") * 100.00,
 				"included_in_print_rate": 1 if shopify_order.get("taxes_included") else 0,
 				"cost_center": setting.cost_center,
@@ -181,15 +181,12 @@ def get_tax_account_head(tax):
 
 	return tax_account
 
-def get_tax_account_description(tax, fallback):
-	tax_title = tax.get("title").encode("utf-8")
+def get_tax_account_description(tax):
+	tax_title = tax.get("title")
 
 	tax_description = frappe.db.get_value(
 		"Shopify Tax Account", {"parent": SETTING_DOCTYPE, "shopify_tax": tax_title}, "tax_description",
 	)
-
-	if not tax_description:
-		tax_description = fallback;
 
 	return tax_description
 


### PR DESCRIPTION
* Add field in child doctype
* Change description to consider specified field first, fallback to default if not available