### PR TITLE
feat: configurable interval for inventory sync

### DIFF
--- a/ecommerce_integrations/controllers/scheduling.py
+++ b/ecommerce_integrations/controllers/scheduling.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe.utils import get_datetime, add_to_date, cint, now
+
+
+def need_to_run(setting, interval_field, timestamp_field) -> bool:
+	"""A utility function to make "configurable" scheduled events.
+
+	If timestamp_field is older than current_time - inveterval_field then this function updates the timestamp_field to `now()` and returns True,
+	otherwise False.
+	This can be used to make "configurable" scheduled events.
+	Assumptions:
+	        - interval_field is in minutes.
+	        - timestamp field is datetime field.
+	        - This function is called from scheuled job with less frequency than lowest interval_field. Ideally, every minute.
+	"""
+	interval = frappe.db.get_single_value(setting, interval_field, cache=True)
+	last_run = frappe.db.get_single_value(setting, timestamp_field)
+
+	if get_datetime() < get_datetime(add_to_date(last_run, minutes=cint(interval, default=10))):
+		return False
+
+	frappe.db.set_value(setting, None, timestamp_field, now(), update_modified=False)
+	return True

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -100,12 +100,9 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
-	"all": [ ],
+	"all": ["ecommerce_integrations.shopify.inventory.update_inventory_on_shopify"],
 	"daily": [ ],
-	"hourly": [
-		"ecommerce_integrations.shopify.inventory.update_inventory_on_shopify",
-		"ecommerce_integrations.shopify.order.sync_old_orders"
-	],
+	"hourly": ["ecommerce_integrations.shopify.order.sync_old_orders"],
 	"weekly": [ ],
 	"monthly": [ ],
 }

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
@@ -44,14 +44,16 @@
   "update_shopify_item_on_update",
   "inventory_sync_section",
   "update_erpnext_stock_levels_to_shopify",
+  "inventory_sync_frequency",
   "fetch_shopify_locations",
   "shopify_warehouse_mapping",
-  "is_old_data_migrated",
   "sync_old_orders_section",
   "sync_old_orders",
   "column_break_45",
   "old_orders_from",
-  "old_orders_to"
+  "old_orders_to",
+  "is_old_data_migrated",
+  "last_inventory_sync"
  ],
  "fields": [
   {
@@ -329,12 +331,26 @@
   {
    "fieldname": "column_break_45",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "60",
+   "fieldname": "inventory_sync_frequency",
+   "fieldtype": "Select",
+   "label": "Inventory Sync Frequency (In Minutes)",
+   "options": "5\n10\n15\n30\n60"
+  },
+  {
+   "fieldname": "last_inventory_sync",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "Last Inventory Sync",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-20 13:47:40.636720",
+ "modified": "2021-06-14 19:30:13.839383",
  "modified_by": "Administrator",
  "module": "shopify",
  "name": "Shopify Setting",

--- a/ecommerce_integrations/shopify/inventory.py
+++ b/ecommerce_integrations/shopify/inventory.py
@@ -9,6 +9,7 @@ from ecommerce_integrations.controllers.inventory import (
 	get_inventory_levels,
 	update_inventory_sync_status,
 )
+from ecommerce_integrations.controllers.scheduling import need_to_run
 from ecommerce_integrations.shopify.connection import temp_shopify_session
 from ecommerce_integrations.shopify.constants import MODULE_NAME, SETTING_DOCTYPE
 from ecommerce_integrations.shopify.utils import create_shopify_log
@@ -22,6 +23,9 @@ def update_inventory_on_shopify() -> None:
 	setting = frappe.get_doc(SETTING_DOCTYPE)
 
 	if not setting.is_enabled() or not setting.update_erpnext_stock_levels_to_shopify:
+		return
+
+	if not need_to_run(SETTING_DOCTYPE, "inventory_sync_frequency", "last_inventory_sync"):
 		return
 
 	warehous_map = setting.get_erpnext_to_integration_wh_mapping()


### PR DESCRIPTION
Make inventory sync configurable (earlier it was fixed to 1 hour)

Options: 5, 10, 15, 30, 60 minutes.

![Screenshot 2021-06-14 at 7 33 44 PM](https://user-images.githubusercontent.com/9079960/121905511-db447180-cd47-11eb-8956-6ac227da7077.png)


Note: If `scheduler_tick_interval` is more than 5 minutes then this configuration won't work. The default value is 60 seconds.