### PR TITLE
fix: remove explicit commits

### DIFF
--- a/ecommerce_integrations/controllers/customer.py
+++ b/ecommerce_integrations/controllers/customer.py
@@ -40,8 +40,6 @@ class EcommerceCustomer:
 		customer.flags.ignore_mandatory = True
 		customer.insert(ignore_permissions=True)
 
-		frappe.db.commit()
-
 	def get_customer_address_doc(self, address_type: str):
 		try:
 			customer = self.get_customer_doc().name
@@ -65,8 +63,6 @@ class EcommerceCustomer:
 			}
 		).insert(ignore_mandatory=True)
 
-		frappe.db.commit()
-
 	def create_customer_contact(self, contact: Dict[str, str]) -> None:
 		"""Create contact from dictionary containing fields used in Address doctype of ERPNext."""
 
@@ -79,5 +75,3 @@ class EcommerceCustomer:
 				"links": [{"link_doctype": "Customer", "link_name": customer_doc.name}],
 			}
 		).insert(ignore_mandatory=True)
-
-		frappe.db.commit()

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -159,5 +159,3 @@ def create_ecommerce_item(
 	)
 
 	ecommerce_item.insert()
-
-	frappe.db.commit()

--- a/ecommerce_integrations/shopify/fulfillment.py
+++ b/ecommerce_integrations/shopify/fulfillment.py
@@ -55,7 +55,6 @@ def create_delivery_note(shopify_order, setting, so):
 			if shopify_order.get("note"):
 				dn.add_comment(text=f"Order Note: {shopify_order.get('note')}")
 
-			frappe.db.commit()
 
 
 def get_fulfillment_items(dn_items, fulfillment_items, location_id=None):

--- a/ecommerce_integrations/shopify/invoice.py
+++ b/ecommerce_integrations/shopify/invoice.py
@@ -56,8 +56,6 @@ def create_sales_invoice(shopify_order, setting, so):
 		if shopify_order.get("note"):
 			sales_invoice.add_comment(text=f"Order Note: {shopify_order.get('note')}")
 
-		frappe.db.commit()
-
 
 def set_cost_center(items, cost_center):
 	for item in items:

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -121,7 +121,6 @@ def create_sales_order(shopify_order, setting, company=None):
 	else:
 		so = frappe.get_doc("Sales Order", so)
 
-	frappe.db.commit()
 	return so
 
 


### PR DESCRIPTION
Both Background jobs and scheduler commit upon successful completion.

These manual commits are unnecessary and can cause inconsistency.