### PR TITLE
fix: tax computation for item taxes

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -83,6 +83,7 @@ def resync(method, name, request_data):
 	frappe.only_for("System Manager")
 
 	frappe.db.set_value("Ecommerce Integration Log", name, "status", "Queued", update_modified=False)
+	frappe.db.set_value("Ecommerce Integration Log", name, "traceback", "", update_modified=False)
 	frappe.enqueue(
 		method=method,
 		queue="short",


### PR DESCRIPTION
Problem: When two different items have different taxation in single order the tax computation is incorrect.
Solution: Manually create the tax distribution on tax rows and avoid recomputation.

depends on pending changes in erpnext. 