### PR TITLE
fix(shopify): don't run migration before enabling

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -47,7 +47,7 @@ class ShopifySetting(SettingController):
 			setup_custom_fields()
 
 	def on_update(self):
-		if not self.is_old_data_migrated:
+		if self.is_enabled() and not self.is_old_data_migrated:
 			migrate_from_old_connector()
 
 	def _handle_webhooks(self):


### PR DESCRIPTION
While harmless, this is getting triggered during install which will result in error.

closes https://github.com/frappe/ecommerce_integrations/issues/85 