### PR TITLE
chore: typo fix

### DIFF
--- a/ecommerce_integrations/controllers/tests/test_setting.py
+++ b/ecommerce_integrations/controllers/tests/test_setting.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.js
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Ecommerce Integration Log', {
 	refresh: function(frm) {

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import json
 

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/test_ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/test_ecommerce_integration_log.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.js
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Ecommerce Item', {
 	// refresh: function(frm) {

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 from typing import Dict, Optional
 

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/test_ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/test_ecommerce_item.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import unittest
 

--- a/ecommerce_integrations/shopify/constants.py
+++ b/ecommerce_integrations/shopify/constants.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 
 MODULE_NAME = "shopify"

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.js
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.provide("ecommerce_integrations.shopify.shopify_setting");
 

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 from typing import Dict, List
 

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/test_shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/test_shopify_setting.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import unittest
 

--- a/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_tax_account/shopify_tax_account.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/shopify/doctype/shopify_warehouse_mapping/shopify_warehouse_mapping.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_warehouse_mapping/shopify_warehouse_mapping.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/shopify/doctype/shopify_webhooks/shopify_webhooks.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_webhooks/shopify_webhooks.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/shopify/tests/test_connection.py
+++ b/ecommerce_integrations/shopify/tests/test_connection.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import unittest
 

--- a/ecommerce_integrations/shopify/tests/test_order.py
+++ b/ecommerce_integrations/shopify/tests/test_order.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import json
 import unittest

--- a/ecommerce_integrations/shopify/tests/test_product.py
+++ b/ecommerce_integrations/shopify/tests/test_product.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import frappe
 

--- a/ecommerce_integrations/shopify/utils.py
+++ b/ecommerce_integrations/shopify/utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 from typing import List
 
 import frappe

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/test_unicommerce_channel.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/test_unicommerce_channel.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/unicommerce_channel.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/unicommerce_channel.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on("Unicommerce Channel", {
 	onload: function (frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/unicommerce_channel.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_channel/unicommerce_channel.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import frappe
 from frappe import _

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_manifest_item/unicommerce_manifest_item.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_manifest_item/unicommerce_manifest_item.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/test_unicommerce_package_type.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/test_unicommerce_package_type.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/unicommerce_package_type.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/unicommerce_package_type.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Unicommerce Package Type', {
 	// refresh: function(frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/unicommerce_package_type.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_package_type/unicommerce_package_type.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/test_unicommerce_settings.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/test_unicommerce_settings.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 import frappe
 import responses

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on("Unicommerce Settings", {
 	refresh(frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 from typing import Dict, List
 

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/test_unicommerce_shipment_manifest.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/test_unicommerce_shipment_manifest.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/unicommerce_shipment_manifest.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/unicommerce_shipment_manifest.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on("Unicommerce Shipment Manifest", {
 	refresh(frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/unicommerce_shipment_manifest.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipment_manifest/unicommerce_shipment_manifest.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import json
 from typing import Optional

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/test_unicommerce_shipping_method.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/test_unicommerce_shipping_method.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/unicommerce_shipping_method.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/unicommerce_shipping_method.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Unicommerce Shipping Method', {
 	// refresh: function(frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/unicommerce_shipping_method.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_method/unicommerce_shipping_method.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/test_unicommerce_shipping_provider.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/test_unicommerce_shipping_provider.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/unicommerce_shipping_provider.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/unicommerce_shipping_provider.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Unicommerce Shipping Provider', {
 	// refresh: function(frm) {

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/unicommerce_shipping_provider.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_shipping_provider/unicommerce_shipping_provider.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_warehouses/unicommerce_warehouses.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_warehouses/unicommerce_warehouses.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/zenoti/doctype/zenoti_cost_center_and_warehouse_mapping/zenoti_cost_center_and_warehouse_mapping.py
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_cost_center_and_warehouse_mapping/zenoti_cost_center_and_warehouse_mapping.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/test_zenoti_error_logs.py
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/test_zenoti_error_logs.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/zenoti_error_logs.js
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/zenoti_error_logs.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Zenoti Error Logs', {
 	// refresh: function(frm) {

--- a/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/zenoti_error_logs.py
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_error_logs/zenoti_error_logs.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 # import frappe
 from frappe.model.document import Document

--- a/ecommerce_integrations/zenoti/doctype/zenoti_settings/test_zenoti_settings.py
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_settings/test_zenoti_settings.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and Contributors
-# See LICESNE
+# See LICENSE
 
 # import frappe
 import unittest

--- a/ecommerce_integrations/zenoti/doctype/zenoti_settings/zenoti_settings.js
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_settings/zenoti_settings.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Frappe and contributors
-// For license information, please see LICESNE
+// For license information, please see LICENSE
 
 frappe.ui.form.on('Zenoti Settings', {
 	setup: function(frm){

--- a/ecommerce_integrations/zenoti/doctype/zenoti_settings/zenoti_settings.py
+++ b/ecommerce_integrations/zenoti/doctype/zenoti_settings/zenoti_settings.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Frappe and contributors
-# For license information, please see LICESNE
+# For license information, please see LICENSE
 
 import frappe
 import requests


### PR DESCRIPTION
Rename all occurrences of `LICESNE` to `LICENSE`.