### PR TITLE
feat: Auto GRN settings and stock entry type

### DIFF
--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -110,6 +110,7 @@ doc_events = {
 	"Stock Entry": {
 		"validate": "ecommerce_integrations.unicommerce.grn.validate_stock_entry_for_grn",
 		"on_submit": "ecommerce_integrations.unicommerce.grn.upload_grn",
+		"on_cancel": "ecommerce_integrations.unicommerce.grn.prevent_grn_cancel",
 	},
 }
 

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -107,6 +107,10 @@ doc_events = {
 		"on_update_after_submit": "ecommerce_integrations.unicommerce.order.update_shipping_info",
 		"on_cancel": "ecommerce_integrations.unicommerce.status_updater.ignore_pick_list_on_sales_order_cancel",
 	},
+	"Stock Entry": {
+		"validate": "ecommerce_integrations.unicommerce.grn.validate_stock_entry_for_grn",
+		"on_submit": "ecommerce_integrations.unicommerce.grn.upload_grn",
+	},
 }
 
 # Scheduled Tasks

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -36,6 +36,7 @@ doctype_js = {
 	"Sales Order": "public/js/unicommerce/sales_order.js",
 	"Sales Invoice": "public/js/unicommerce/sales_invoice.js",
 	"Item": "public/js/unicommerce/item.js",
+	"Stock Entry": "public/js/unicommerce/stock_entry.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/ecommerce_integrations/public/js/unicommerce/stock_entry.js
+++ b/ecommerce_integrations/public/js/unicommerce/stock_entry.js
@@ -1,0 +1,25 @@
+frappe.ui.form.on("Stock Entry", {
+	refresh(frm) {
+		if (frm.doc.stock_entry_type == "GRN on Unicommerce") {
+			frm.add_custom_button(
+				__("Open GRNs"),
+				function () {
+					frappe.call({
+						method:
+							"ecommerce_integrations.unicommerce.utils.get_unicommerce_document_url",
+						args: {
+							code: '',
+							doctype: frm.doc.doctype,
+						},
+						callback: function (r) {
+							if (!r.exc) {
+								window.open(r.message, "_blank");
+							}
+						},
+					});
+				},
+				__("Unicommerce")
+			);
+		}
+	},
+});

--- a/ecommerce_integrations/unicommerce/constants.py
+++ b/ecommerce_integrations/unicommerce/constants.py
@@ -33,6 +33,9 @@ IS_COD_CHECKBOX = "unicommerce_is_cod"
 SHIPPING_METHOD_FIELD = "unicommerce_shipping_method"
 
 
+GRN_STOCK_ENTRY_TYPE = "GRN on Unicommerce"
+
+
 # Tax -> Unicommerce tax amount field mapping
 TAX_FIELDS_MAPPING = {
 	"igst": "integratedGst",

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.json
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.json
@@ -34,6 +34,9 @@
   "enable_inventory_sync",
   "inventory_sync_frequency",
   "warehouse_mapping",
+  "grn_settings_section",
+  "use_stock_entry_for_grn",
+  "vendor_code",
   "sync_status_section",
   "last_order_sync",
   "column_break_20",
@@ -235,12 +238,30 @@
    "fieldtype": "Int",
    "label": "Sync Order Status Days ",
    "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "grn_settings_section",
+   "fieldtype": "Section Break",
+   "label": "GRN settings"
+  },
+  {
+   "default": "0",
+   "description": "Material Transfer entries can be used for transferring stock to Unicommerce using Auto GRN API",
+   "fieldname": "use_stock_entry_for_grn",
+   "fieldtype": "Check",
+   "label": "Use Stock Entry for GRN"
+  },
+  {
+   "fieldname": "vendor_code",
+   "fieldtype": "Data",
+   "label": "Vendor Code"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-14 11:39:59.994872",
+ "modified": "2021-12-06 12:30:48.168894",
  "modified_by": "Administrator",
  "module": "unicommerce",
  "name": "Unicommerce Settings",

--- a/ecommerce_integrations/unicommerce/grn.py
+++ b/ecommerce_integrations/unicommerce/grn.py
@@ -1,39 +1,196 @@
+from dataclasses import dataclass
+from typing import List
+
 import frappe
+from erpnext.stock.doctype.batch.batch import Batch
 from frappe import _
+from frappe.utils import cint, getdate
+from frappe.utils.csvutils import UnicodeWriter
+from frappe.utils.file_manager import save_file
 
-from ecommerce_integrations.unicommerce.constants import GRN_STOCK_ENTRY_TYPE, SETTINGS_DOCTYPE
+from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient
+from ecommerce_integrations.unicommerce.constants import (
+	GRN_STOCK_ENTRY_TYPE,
+	MODULE_NAME,
+	SETTINGS_DOCTYPE,
+)
+from ecommerce_integrations.unicommerce.utils import remove_non_alphanumeric_chars
+
+CSV_HEADER_LINE = (
+	"Vendor Code*,Vendor Invoice Number*,Purchase Order Code,Vendor Invoice Date*,Sku"
+	" Code*,Qty*,Item Code,Item Details,Shelf Code,MRP,Unit Price,Manufacturing Date,Expiry date"
+	" as dd/MM/yyyy,Vendor Batch Number\r\n"
+)
 
 
-def validate_stock_entry_for_grn(doc, method=None):
-	stock_entry = doc
+@dataclass
+class GRNItemRow:
+	vendor_code: str
+	vendor_invoice_number: str
+	invoice_date: str
+	sku: str
+	qty: int
+	item_code: str
+	purchase_order: str = ""
+	manufacturing_date: str = ""
+	expiry_date: str = ""
+	batch_number: str = ""
+	shelf_code: str = ""
+	item_details: str = ""
+	mrp: str = 0.0
+	unit_price: str = 0.0
 
+	def get_ordered_fields(self):
+		return [
+			self.vendor_code,
+			self.vendor_invoice_number,
+			self.purchase_order,
+			self.invoice_date,
+			self.sku,
+			self.qty,
+			self.item_code,
+			self.item_details,
+			self.shelf_code,
+			self.mrp,
+			self.unit_price,
+			self.manufacturing_date,
+			self.expiry_date,
+			self.batch_number,
+		]
+
+
+def is_unicommerce_grn(stock_entry) -> bool:
 	if stock_entry.stock_entry_type != GRN_STOCK_ENTRY_TYPE:
-		return
+		return False
 
 	grn_enabled = frappe.db.get_single_value(SETTINGS_DOCTYPE, "use_stock_entry_for_grn")
-
 	if not grn_enabled:
 		frappe.throw(
 			_("Auto GRN not enabled in Unicommerce settings. Can not use Stock Entry Type: {}").format(
 				GRN_STOCK_ENTRY_TYPE
 			)
 		)
+	return True
+
+
+def validate_stock_entry_for_grn(doc, method=None):
+	stock_entry = doc
+	if not is_unicommerce_grn(stock_entry):
+		return
 
 	settings = frappe.get_doc(SETTINGS_DOCTYPE)
 
 	if not settings.is_enabled():
 		return
 
-	warehouses = {d.t_warehouse for d in doc.items}
-	mapped_warehouses = set(settings.get_erpnext_warehouses(all_wh=True))
+	get_facility_code(stock_entry, settings)
 
-	unknown_warehouse = warehouses - mapped_warehouses
-	if unknown_warehouse:
-		msg = _("Following warehouses do not have Unicommerce facilities mapped to them.")
-		msg += "<br>"
-		msg += ",".join(unknown_warehouse)
+
+def get_facility_code(stock_entry, unicommerce_settings) -> str:
+	"""Validate that facility has single warehouse and return facility code."""
+
+	target_warehouses = {d.t_warehouse for d in stock_entry.items}
+	if len(target_warehouses) > 1:
+		frappe.throw(
+			_("{} only supports one target warehouse (unicommerce facility)").format(GRN_STOCK_ENTRY_TYPE)
+		)
+
+	warehouse = list(target_warehouses)[0]
+	warehouse_mapping = unicommerce_settings.get_erpnext_to_integration_wh_mapping(all_wh=True)
+
+	facility = warehouse_mapping.get(warehouse)
+	if not facility:
+		msg = _("{} warehouse does not have Unicommerce facilities mapped to it.").format(warehouse)
 		frappe.throw(msg, title="Unmapped Unicommerce Facility")
+
+	return facility
 
 
 def upload_grn(doc, method=None):
-	pass
+	stock_entry = doc
+	if not is_unicommerce_grn(stock_entry):
+		return
+
+	settings = frappe.get_doc(SETTINGS_DOCTYPE)
+	facility_code = get_facility_code(stock_entry, settings)
+	csv_file = _prepare_grn_import_csv(doc)
+
+	create_auto_grn_import(csv_file, facility_code=facility_code)
+
+
+def _prepare_grn_import_csv(stock_entry) -> str:
+	"""Prepare CSV file in Unicommerce auto grn api format and attach it to Stock Entry
+	returns: filename of generated csv.
+	"""
+
+	rows = []
+	vendor_code = frappe.db.get_single_value(SETTINGS_DOCTYPE, "vendor_code")
+
+	for item in stock_entry.items:
+		price = item.basic_rate
+		invoice_date = _get_unicommerce_format_date(stock_entry.posting_date)
+
+		batch_details = frappe.db.get_value(
+			"Batch", item.batch_no, fieldname=["manufacturing_date", "expiry_date"], as_dict=True
+		)
+		manufacturing_date = _get_unicommerce_format_date(batch_details.manufacturing_date)
+		expiry_date = _get_unicommerce_format_date(batch_details.expiry_date)
+
+		sku = frappe.db.get_value(
+			"Ecommerce Item",
+			{"erpnext_item_code": item.item_code, "integration": MODULE_NAME},
+			"integration_item_code",
+		)
+		if not sku:
+			frappe.throw(_("Item {} does not have associated Unicommerce SKU.").format(item.item_code))
+
+		row = GRNItemRow(
+			vendor_code=vendor_code,
+			vendor_invoice_number=stock_entry.name,
+			invoice_date=invoice_date,
+			sku=sku,
+			qty=cint(item.qty),
+			item_code=sku,
+			manufacturing_date=manufacturing_date,
+			expiry_date=expiry_date,
+			batch_number=item.batch_no,
+			mrp=price,
+			unit_price=price,
+		)
+		rows.append(row)
+
+	file_name = remove_non_alphanumeric_chars(stock_entry.name)
+	file = save_file(
+		fname=f"GRN-{file_name}.csv",
+		content=_get_csv_content(rows),
+		dt=stock_entry.doctype,
+		dn=stock_entry.name,
+	)
+	return file.file_name
+
+
+def _get_csv_content(rows: List[GRNItemRow]) -> bytes:
+
+	writer = UnicodeWriter()
+
+	for row in rows:
+		writer.writerow(row.get_ordered_fields())
+
+	csv_content = CSV_HEADER_LINE + writer.getvalue()
+	return csv_content.encode("utf-8")
+
+
+def _get_unicommerce_format_date(date) -> str:
+	if date:
+		return getdate(date).strftime("%Y/%m/%d")
+	return ""
+
+
+def create_auto_grn_import(csv_filename: str, facility_code: str, client=None):
+	""" Create new import job for Auto GRN items"""
+	if client is None:
+		client = UnicommerceAPIClient()
+	resp = client.create_import_job(
+		job_name="Auto GRN Items", csv_filename=csv_filename, facility_code=facility_code
+	)
+	return resp

--- a/ecommerce_integrations/unicommerce/grn.py
+++ b/ecommerce_integrations/unicommerce/grn.py
@@ -1,0 +1,39 @@
+import frappe
+from frappe import _
+
+from ecommerce_integrations.unicommerce.constants import GRN_STOCK_ENTRY_TYPE, SETTINGS_DOCTYPE
+
+
+def validate_stock_entry_for_grn(doc, method=None):
+	stock_entry = doc
+
+	if stock_entry.stock_entry_type != GRN_STOCK_ENTRY_TYPE:
+		return
+
+	grn_enabled = frappe.db.get_single_value(SETTINGS_DOCTYPE, "use_stock_entry_for_grn")
+
+	if not grn_enabled:
+		frappe.throw(
+			_("Auto GRN not enabled in Unicommerce settings. Can not use Stock Entry Type: {}").format(
+				GRN_STOCK_ENTRY_TYPE
+			)
+		)
+
+	settings = frappe.get_doc(SETTINGS_DOCTYPE)
+
+	if not settings.is_enabled():
+		return
+
+	warehouses = {d.t_warehouse for d in doc.items}
+	mapped_warehouses = set(settings.get_erpnext_warehouses(all_wh=True))
+
+	unknown_warehouse = warehouses - mapped_warehouses
+	if unknown_warehouse:
+		msg = _("Following warehouses do not have Unicommerce facilities mapped to them.")
+		msg += "<br>"
+		msg += ",".join(unknown_warehouse)
+		frappe.throw(msg, title="Unmapped Unicommerce Facility")
+
+
+def upload_grn(doc, method=None):
+	pass

--- a/ecommerce_integrations/unicommerce/grn.py
+++ b/ecommerce_integrations/unicommerce/grn.py
@@ -194,3 +194,14 @@ def create_auto_grn_import(csv_filename: str, facility_code: str, client=None):
 		job_name="Auto GRN Items", csv_filename=csv_filename, facility_code=facility_code
 	)
 	return resp
+
+
+def prevent_grn_cancel(doc, method=None):
+	if not is_unicommerce_grn(doc):
+		return
+
+	msg = _("This Stock Entry can not be cancelled.")
+	msg += _("To undo this stock entry you need to move the Stock back") + " "
+	msg += _("and remove stock from Unicommerce.")
+
+	frappe.throw(msg, title="GRN Stock Entry can not be cancelled")

--- a/ecommerce_integrations/unicommerce/inventory.py
+++ b/ecommerce_integrations/unicommerce/inventory.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Dict
 
 import frappe
 from frappe.utils import cint, now
@@ -86,14 +86,3 @@ def _update_inventory_sync_status(ecom_item_success_map: Dict[str, bool], timest
 	for ecom_item, status in ecom_item_success_map.items():
 		if status:
 			update_inventory_sync_status(ecom_item, timestamp)
-
-
-@frappe.whitelist()
-def create_auto_grn_import(csv_filename: str, facility_code: str, client=None):
-	""" Create new import job for Auto GRN items"""
-	if client is None:
-		client = UnicommerceAPIClient()
-	resp = client.create_import_job(
-		job_name="Auto GRN Items", csv_filename=csv_filename, facility_code=facility_code
-	)
-	return resp

--- a/ecommerce_integrations/unicommerce/tests/test_client.py
+++ b/ecommerce_integrations/unicommerce/tests/test_client.py
@@ -310,7 +310,7 @@ class TestUnicommerceClient(TestCaseApiClient):
 	def test_bulk_import(self):
 		from frappe.utils.file_manager import save_file
 
-		from ecommerce_integrations.unicommerce.inventory import create_auto_grn_import
+		from ecommerce_integrations.unicommerce.grn import create_auto_grn_import
 
 		csv_file = b"a,b,c\n1,2,3"
 		csv_filename = "test_file.csv"

--- a/ecommerce_integrations/unicommerce/tests/utils.py
+++ b/ecommerce_integrations/unicommerce/tests/utils.py
@@ -15,6 +15,8 @@ class TestCase(unittest.TestCase):
 	config = {
 		"is_enabled": 1,
 		"enable_inventory_sync": 1,
+		"use_stock_entry_for_grn": 1,
+		"vendor_code": "ERP",
 		"default_customer_group": "Individual",
 		"warehouse_mapping": [
 			{"unicommerce_facility_code": "Test-123", "erpnext_warehouse": "Stores - WP", "enabled": 1},

--- a/ecommerce_integrations/unicommerce/utils.py
+++ b/ecommerce_integrations/unicommerce/utils.py
@@ -18,6 +18,7 @@ DOCUMENT_URL_FORMAT = {
 	"Sales Invoice": "https://{site}/order/orderitems?orderCode={code}",
 	"Item": "https://{site}/products/edit?sku={code}",
 	"Unicommerce Shipment Manifest": "https://{site}/manifests/edit?code={code}",
+	"Stock Entry": "https://{site}/grns",
 }
 
 


### PR DESCRIPTION
closes #129 

Change:
1. Setting for enabling GRN using stock entry of material transfer type and add a new transfer type "GRN On Unicommerce"
2. Vendor code configurable in Unicommerce settings. This is a "Fake GRN" only meant for adding stock with batch nos. 
2. Upon submitting a stock entry with GRN on Unicommerce where target warehouse is Unicommerce facility, create a GRN on Unicommerce and map following fields:
     - Item Code -> SKU, Item_code
     - Qty -> Qty
     - Basic rate -> price and MRP
     - Stock entry number -> vendor invoice number
     - batch no -> batch no
     - batch manufacturing date -> manufacturing date
     - batch expiry date -> expiry date
   

Implementation detail:

- Items table gets converted to CSV of "Auto GRN Import" format and posted to bulk import API. 