### PR TITLE
fix: avoid 0 values payment entry and mark items as sales items by default

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -148,6 +148,7 @@ def create_ecommerce_item(
 	item = {
 		"doctype": "Item",
 		"is_stock_item": 1,
+		"is_sales_item": 1,
 		"item_defaults": [{"company": get_default_company()}],
 	}
 

--- a/ecommerce_integrations/shopify/invoice.py
+++ b/ecommerce_integrations/shopify/invoice.py
@@ -51,7 +51,8 @@ def create_sales_invoice(shopify_order, setting, so):
 		set_cost_center(sales_invoice.items, setting.cost_center)
 		sales_invoice.insert(ignore_mandatory=True)
 		sales_invoice.submit()
-		make_payament_entry_against_sales_invoice(sales_invoice, setting, posting_date)
+		if sales_invoice.grand_total > 0:
+			make_payament_entry_against_sales_invoice(sales_invoice, setting, posting_date)
 
 		if shopify_order.get("note"):
 			sales_invoice.add_comment(text=f"Order Note: {shopify_order.get('note')}")


### PR DESCRIPTION
If the grand total cost on the invoice is 0 it doesn't try to post a payment.

This fixes a problem where ERPNext complains when a payment for 0 is posted.

closes https://github.com/frappe/ecommerce_integrations/issues/162
closes https://github.com/frappe/ecommerce_integrations/issues/157 