### PR TITLE
Fix:  is_sales_item now defaults to 1 when an item is created.

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -148,6 +148,7 @@ def create_ecommerce_item(
 	item = {
 		"doctype": "Item",
 		"is_stock_item": 1,
+		"is_sales_item": 1,
 		"item_defaults": [{"company": get_default_company()}],
 	}
 


### PR DESCRIPTION
This is a fix for issue #157 .