### PR TITLE
fix: add template name in variant item name

### DIFF
--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -162,7 +162,7 @@ class ShopifyProduct:
 					"id": product_dict.get("id"),
 					"variant_id": variant.get("id"),
 					"item_code": variant.get("id"),
-					"title": product_dict.get("title", "").strip() + '-' + variant.get("title"),
+					"title": product_dict.get("title", "").strip() + "-" + variant.get("title"),
 					"product_type": product_dict.get("product_type"),
 					"sku": variant.get("sku"),
 					"uom": template_item.stock_uom or _("Nos"),

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -162,7 +162,7 @@ class ShopifyProduct:
 					"id": product_dict.get("id"),
 					"variant_id": variant.get("id"),
 					"item_code": variant.get("id"),
-					"title": variant.get("title"),
+					"title": product_dict.get("title", "").strip() + '-' + variant.get("title"),
 					"product_type": product_dict.get("product_type"),
 					"sku": variant.get("sku"),
 					"uom": template_item.stock_uom or _("Nos"),


### PR DESCRIPTION
I have 2 items with the same attribute and it is creating variant items with the same item name.  It's hard to identify the item from attribute value so better to have product name with variant attributes