### PR TITLE
fix: bump shopify api version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     hooks:
       - id: black
         exclude: ".*setup.py$"
+        additional_dependencies: ['click==8.0.4']
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.9.1

--- a/ecommerce_integrations/shopify/constants.py
+++ b/ecommerce_integrations/shopify/constants.py
@@ -6,7 +6,7 @@ MODULE_NAME = "shopify"
 SETTING_DOCTYPE = "Shopify Setting"
 OLD_SETTINGS_DOCTYPE = "Shopify Settings"
 
-API_VERSION = "2021-04"
+API_VERSION = "2022-04"
 
 WEBHOOK_EVENTS = [
 	"orders/create",


### PR DESCRIPTION
No breaking changes that affect integration as per: https://shopify.dev/api/release-notes/2022-04

closes #180 
closes #179 