### PR TITLE
fix: dont upload price on unicommerce

### DIFF
--- a/ecommerce_integrations/unicommerce/grn.py
+++ b/ecommerce_integrations/unicommerce/grn.py
@@ -37,8 +37,8 @@ class GRNItemRow:
 	batch_number: str = ""
 	shelf_code: str = ""
 	item_details: str = ""
-	mrp: str = 0.0
-	unit_price: str = 0.0
+	mrp: str = ""
+	unit_price: str = ""
 
 	def get_ordered_fields(self):
 		return [
@@ -144,7 +144,6 @@ def _prepare_grn_import_csv(stock_entry) -> str:
 	vendor_code = frappe.db.get_single_value(SETTINGS_DOCTYPE, "vendor_code")
 
 	for item in stock_entry.items:
-		price = item.basic_rate
 		invoice_date = _get_unicommerce_format_date(stock_entry.posting_date)
 
 		batch_details = frappe.db.get_value(
@@ -175,8 +174,6 @@ def _prepare_grn_import_csv(stock_entry) -> str:
 			manufacturing_date=manufacturing_date,
 			expiry_date=expiry_date,
 			batch_number=item.batch_no,
-			mrp=price,
-			unit_price=price,
 		)
 		rows.append(row)
 


### PR DESCRIPTION
Uploading difference prices via GRN causes this stupid failure `SKU: sku already present with different Unit Price`