### PR TITLE
refactor: sync orders from multiple amazon account

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -5,7 +5,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "enable_amazon",
+  "is_active",
   "section_break_4",
   "iam_arn",
   "refresh_token",
@@ -40,9 +40,12 @@
  "fields": [
   {
    "default": "0",
-   "fieldname": "enable_amazon",
+   "fieldname": "is_active",
    "fieldtype": "Check",
-   "label": "Enable Amazon"
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Is Active"
   },
   {
    "fieldname": "section_break_4",
@@ -70,7 +73,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Client ID",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "client_secret",
@@ -87,7 +91,8 @@
    "fieldname": "aws_access_key",
    "fieldtype": "Data",
    "label": "AWS Access Key",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "aws_secret_key",
@@ -231,9 +236,8 @@
    "report_hide": 1
   }
  ],
- "issingle": 1,
  "links": [],
- "modified": "2022-02-07 16:16:17.733273",
+ "modified": "2022-04-19 17:08:28.354861",
  "modified_by": "Administrator",
  "module": "Amazon",
  "name": "Amazon SP API Settings",
@@ -250,7 +254,6 @@
    "write": 1
   }
  ],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/test_amazon_sp_api_settings.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/test_amazon_sp_api_settings.py
@@ -217,7 +217,7 @@ class TestAmazonSettings:
 
 			return item_group_name
 
-		self.enable_amazon = 1
+		self.is_active = 1
 		self.iam_arn = "********************"
 		self.refresh_token = "********************"
 		self.client_id = "********************"
@@ -241,19 +241,19 @@ class TestAmazonSettings:
 
 class TestAmazonRepository(AmazonRepository):
 	def __init__(self) -> None:
-		self.amz_settings = TestAmazonSettings()
+		self.amz_setting = TestAmazonSettings()
 		self.instance_params = dict(
-			iam_arn=self.amz_settings.iam_arn,
-			client_id=self.amz_settings.client_id,
-			client_secret=self.amz_settings.client_secret,
-			refresh_token=self.amz_settings.refresh_token,
-			aws_access_key=self.amz_settings.aws_access_key,
-			aws_secret_key=self.amz_settings.aws_secret_key,
-			country_code=self.amz_settings.country,
+			iam_arn=self.amz_setting.iam_arn,
+			client_id=self.amz_setting.client_id,
+			client_secret=self.amz_setting.client_secret,
+			refresh_token=self.amz_setting.refresh_token,
+			aws_access_key=self.amz_setting.aws_access_key,
+			aws_secret_key=self.amz_setting.aws_secret_key,
+			country_code=self.amz_setting.country,
 		)
 
 	def call_sp_api_method(self, sp_api_method, **kwargs):
-		max_retries = self.amz_settings.max_retry_limit
+		max_retries = self.amz_setting.max_retry_limit
 
 		for x in range(max_retries):
 			try:

--- a/ecommerce_integrations/patches.txt
+++ b/ecommerce_integrations/patches.txt
@@ -1,1 +1,2 @@
 ecommerce_integrations.patches.update_shopify_custom_fields
+ecommerce_integrations.patches.copy_amazon_single_doc

--- a/ecommerce_integrations/patches/copy_amazon_single_doc.py
+++ b/ecommerce_integrations/patches/copy_amazon_single_doc.py
@@ -1,0 +1,38 @@
+import frappe
+
+
+def execute():
+	if frappe.db.get_single_value("Amazon SP API Settings", "enable_amazon"):
+		try:
+			amz_settings = frappe.get_doc("Amazon SP API Settings")
+
+			frappe.reload_doc("amazon", "doctype", frappe.scrub("Amazon SP API Settings"))
+
+			new_amz_setting = frappe.new_doc("Amazon SP API Settings")
+			new_amz_setting.is_active = amz_settings.enable_amazon
+			new_amz_setting.iam_arn = amz_settings.iam_arn
+			new_amz_setting.refresh_token = amz_settings.refresh_token
+			new_amz_setting.client_id = amz_settings.client_id
+			new_amz_setting.client_secret = amz_settings.get_password("client_secret")
+			new_amz_setting.aws_access_key = amz_settings.aws_access_key
+			new_amz_setting.aws_secret_key = amz_settings.get_password("aws_secret_key")
+			new_amz_setting.country = amz_settings.country
+			new_amz_setting.company = amz_settings.company
+			new_amz_setting.warehouse = amz_settings.warehouse
+			new_amz_setting.parent_item_group = amz_settings.parent_item_group
+			new_amz_setting.price_list = amz_settings.price_list
+			new_amz_setting.customer_group = amz_settings.customer_group
+			new_amz_setting.territory = amz_settings.territory
+			new_amz_setting.customer_type = amz_settings.customer_type
+			new_amz_setting.market_place_account_group = amz_settings.market_place_account_group
+			new_amz_setting.after_date = amz_settings.after_date
+			new_amz_setting.taxes_charges = amz_settings.taxes_charges
+			new_amz_setting.enable_sync = amz_settings.enable_sync
+			new_amz_setting.max_retry_limit = amz_settings.max_retry_limit
+			new_amz_setting.is_old_data_migrated = amz_settings.is_old_data_migrated
+
+			new_amz_setting.insert()
+		except Exception as e:
+			frappe.log_error(
+				message=e, title=f'Method "{execute.__name__}" failed',
+			)


### PR DESCRIPTION
Multiple documents can be added with "is_active" and "enable_sync" checked to sync orders from multiple amazon accounts every hour via hook. To sync orders from a single account, click the "Sync Orders" button. 