### PR TITLE
fix: misc fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - develop
       - main
+  schedule:
+    # Run everday at midnight UTC / 5:30 IST
+    - cron: "0 0 * * *"
 
 concurrency:
   group: develop-${{ github.event.number }}

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -6,6 +6,8 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 from frappe.utils import strip_html
 from frappe.utils.data import cstr
 
@@ -26,6 +28,13 @@ class EcommerceIntegrationLog(Document):
 		if title:
 			title = strip_html(title)
 			self.title = title if len(title) < 100 else title[:100] + "..."
+
+	@staticmethod
+	def clear_old_logs(days=90):
+		table = frappe.qb.DocType("Ecommerce Integration Log")
+		frappe.db.delete(
+			table, filters=((table.modified < (Now() - Interval(days=days)))) & (table.status == "Success")
+		)
 
 
 def create_log(

--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.js
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.js
@@ -31,6 +31,9 @@ frappe.ui.form.on("Shopify Setting", {
 		frm.add_custom_button(__('Import Products'), function () {
 			frappe.set_route('shopify-import-products');
 		});
+		frm.add_custom_button(__("View Logs"), () => {
+			frappe.set_route("List", "Ecommerce Integration Log", {"integration": "Shopify"});
+		});
 	}
 });
 

--- a/ecommerce_integrations/unicommerce/api_client.py
+++ b/ecommerce_integrations/unicommerce/api_client.py
@@ -43,6 +43,7 @@ class UnicommerceAPIClient:
 		body: Optional[JsonDict] = None,
 		params: Optional[JsonDict] = None,
 		files: Optional[JsonDict] = None,
+		log_error=True,
 	) -> Tuple[JsonDict, bool]:
 
 		if headers is None:
@@ -60,7 +61,8 @@ class UnicommerceAPIClient:
 			response.reason = cstr(response.reason) + cstr(response.text)
 			response.raise_for_status()
 		except Exception:
-			create_unicommerce_log(status="Error", make_new=True)
+			if log_error:
+				create_unicommerce_log(status="Error", make_new=True)
 			return None, False
 
 		if method == "GET" and "application/json" not in response.headers.get("content-type"):
@@ -81,13 +83,13 @@ class UnicommerceAPIClient:
 
 		return data, status
 
-	def get_unicommerce_item(self, sku: str) -> Optional[JsonDict]:
+	def get_unicommerce_item(self, sku: str, log_error=True) -> Optional[JsonDict]:
 		"""Get Unicommerce item data for specified SKU code.
 
 		ref: https://documentation.unicommerce.com/docs/itemtype-get.html
 		"""
 		item, status = self.request(
-			endpoint="/services/rest/v1/catalog/itemType/get", body={"skuCode": sku}
+			endpoint="/services/rest/v1/catalog/itemType/get", body={"skuCode": sku}, log_error=log_error
 		)
 		if status:
 			return item

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Unicommerce Settings", {
 		}
 
 		frm.add_custom_button(__("View Logs"), () => {
-			frappe.set_route("List", "Ecommerce Integration Log", "List");
+			frappe.set_route("List", "Ecommerce Integration Log", {"integration": "Unicommerce"});
 		});
 
 		let sync_buttons = ["Items", "Orders", "Inventory"];

--- a/ecommerce_integrations/unicommerce/order.py
+++ b/ecommerce_integrations/unicommerce/order.py
@@ -48,9 +48,7 @@ def sync_new_orders(client: UnicommerceAPIClient = None, force=False):
 
 	status = "COMPLETE" if settings.only_sync_completed_orders else None
 
-	new_orders = _get_new_orders(
-		client, from_date=add_to_date(settings.last_order_sync, days=-1), status=status
-	)
+	new_orders = _get_new_orders(client, status=status)
 
 	if new_orders is None:
 		return
@@ -63,12 +61,13 @@ def sync_new_orders(client: UnicommerceAPIClient = None, force=False):
 
 
 def _get_new_orders(
-	client: UnicommerceAPIClient, from_date: str, status: Optional[str]
+	client: UnicommerceAPIClient, status: Optional[str]
 ) -> Optional[Iterator[UnicommerceOrder]]:
 
 	"""Search new sales order from unicommerce."""
 
-	uni_orders = client.search_sales_order(from_date=from_date, status=status)
+	updated_since = 24 * 60  # minutes
+	uni_orders = client.search_sales_order(updated_since=updated_since, status=status)
 	configured_channels = {
 		c.channel_id
 		for c in frappe.get_all("Unicommerce Channel", filters={"enabled": 1}, fields="channel_id")

--- a/ecommerce_integrations/unicommerce/product.py
+++ b/ecommerce_integrations/unicommerce/product.py
@@ -247,7 +247,7 @@ def upload_items_to_unicommerce(
 		item_data = _build_unicommerce_item(item_code)
 		sku = item_data.get("skuCode")
 
-		item_exists = bool(client.get_unicommerce_item(sku))
+		item_exists = bool(client.get_unicommerce_item(sku, log_error=False))
 		_, status = client.create_update_item(item_data, update=item_exists)
 
 		if status:


### PR DESCRIPTION
- support configuring log settings for e-commerce integration logs (v14 only) https://github.com/frappe/frappe/pull/17159 
- show log button on shopify setting page
- better handle SO sync for unicommerce when using in "completed orders" mode
- dont log error when querying for item's existence 