### PR TITLE
fix: phone number mapping in address

### DIFF
--- a/ecommerce_integrations/shopify/customer.py
+++ b/ecommerce_integrations/shopify/customer.py
@@ -125,7 +125,7 @@ def _map_address_fields(shopify_address, customer_name, address_type, email):
 	}
 
 	phone = shopify_address.get("phone")
-	if validate_phone_number(phone):
+	if validate_phone_number(phone, throw=False):
 		address_fields["phone"] = phone
 
 	return address_fields

--- a/ecommerce_integrations/shopify/customer.py
+++ b/ecommerce_integrations/shopify/customer.py
@@ -121,7 +121,10 @@ def _map_address_fields(shopify_address, customer_name, address_type, email):
 		"state": shopify_address.get("province"),
 		"pincode": shopify_address.get("zip"),
 		"country": shopify_address.get("country"),
-		"phone": validate_phone_number(shopify_address.get("phone"), throw=False) or None,
 		"email_id": email,
 	}
+
+	if validate_phone_number(shopify_address.get("phone"), throw=False):
+		address_fields["phone"] = shopify_address.get("phone")
+
 	return address_fields

--- a/ecommerce_integrations/shopify/customer.py
+++ b/ecommerce_integrations/shopify/customer.py
@@ -124,7 +124,8 @@ def _map_address_fields(shopify_address, customer_name, address_type, email):
 		"email_id": email,
 	}
 
-	if validate_phone_number(shopify_address.get("phone"), throw=False):
-		address_fields["phone"] = shopify_address.get("phone")
+	phone = shopify_address.get("phone")
+	if validate_phone_number(phone):
+		address_fields["phone"] = phone
 
 	return address_fields


### PR DESCRIPTION
**Bug**

In `def _map_address_fields()` phone number validation returned boolean of True or False as a phone. 

**Solved**

- Validated Phone Number
-  Assigned value of phone from Shopify address to the dictionary.