### PR TITLE
fix(UX): change column name to Variant SKUs in product table

### DIFF
--- a/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
+++ b/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
@@ -138,7 +138,7 @@ shopify.ProductImporter = class {
 					focusable: false,
 				},
 				{
-					name: 'SKUs',
+					name: 'Variant SKUs',
 					editable: false,
 					focusable: false,
 				},
@@ -174,7 +174,7 @@ shopify.ProductImporter = class {
 				// 'Image': product.image && product.image.src && `<img style="height: 50px" src="${product.image.src}">`,
 				'ID': product.id,
 				'Name': product.title,
-				'SKUs': product.variants && product.variants.reduce((a, b) => a + `${b.sku}, `, ''),
+				'Variant SKUs': product.variants && product.variants.reduce((a, b) => a + `${b.sku}, `, ''),
 				'Status': this.getProductSyncStatus(product.synced),
 				'Action': !product.synced ? `<button type="button" class="btn btn-default btn-xs btn-sync mx-2" data-product="${product.id}"> Sync </button>` : '-',
 			}));

--- a/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
+++ b/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
@@ -174,7 +174,7 @@ shopify.ProductImporter = class {
 				// 'Image': product.image && product.image.src && `<img style="height: 50px" src="${product.image.src}">`,
 				'ID': product.id,
 				'Name': product.title,
-				'Variant SKUs': product.variants && product.variants.reduce((a, b) => a + `${b.sku}, `, ''),
+				'Variant SKUs': product.variants && product.variants.map(a => `${a.sku}`).join(', '),
 				'Status': this.getProductSyncStatus(product.synced),
 				'Action': !product.synced ? `<button type="button" class="btn btn-default btn-xs btn-sync mx-2" data-product="${product.id}"> Sync </button>` : '-',
 			}));


### PR DESCRIPTION
In the "Products in Shopify" table,  changed the column name from "SKUs" to "Variant SKUs" to avoid naming confusion between ID (parent) and SKU (variants).

Shopify uses product_id, variant_ids and sku to define the hierarchy of parent and child products while in ERPNext we just have item_code as the UID for parent item as well as the variant item.

<img width="882" alt="Screenshot 2022-09-03 at 2 40 24 AM" src="https://user-images.githubusercontent.com/7890147/188265091-fb08793f-78b4-453c-a5e8-fd3f7f0fa279.png">

<img width="642" alt="image" src="https://user-images.githubusercontent.com/7890147/188265067-224cfb7f-b56b-45d1-b121-dfff0c5e222e.png">
