### PR TITLE
fix: remove the trailing comma after the last SKU

### DIFF
--- a/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
+++ b/ecommerce_integrations/shopify/page/shopify_import_products/shopify_import_products.js
@@ -174,7 +174,7 @@ shopify.ProductImporter = class {
 				// 'Image': product.image && product.image.src && `<img style="height: 50px" src="${product.image.src}">`,
 				'ID': product.id,
 				'Name': product.title,
-				'SKUs': product.variants && product.variants.reduce((a, b) => a + `${b.sku}, `, ''),
+				'SKUs': product.variants && product.variants.map(a => `${a.sku}`).join(', '),
 				'Status': this.getProductSyncStatus(product.synced),
 				'Action': !product.synced ? `<button type="button" class="btn btn-default btn-xs btn-sync mx-2" data-product="${product.id}"> Sync </button>` : '-',
 			}));


### PR DESCRIPTION
**Issue:**
On the Import Shopify Products page, the SKUs column shows a trailing comma after the last SKU (it shows a comma even it there's only one SKU)

**Before:**

<img width="864" alt="Screenshot 2022-09-04 at 6 13 01 PM" src="https://user-images.githubusercontent.com/7890147/188343138-594a192e-c3ad-44ff-b612-a2e6c6723960.png">


**After:**

<img width="854" alt="Screenshot 2022-09-04 at 6 11 30 PM" src="https://user-images.githubusercontent.com/7890147/188343146-88dcafa0-41d9-46dd-afd5-f01fc2241295.png">

**Solution:**
Instead of using the reduce() method to explode the SKUs arrays into separate objects, we can use the map() method and get rid of the trailing comma after the last SKU