### PR TITLE
fix (UX): better wordings for Shopify order sync setting

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
@@ -191,7 +191,7 @@
    "default": "0",
    "fieldname": "sync_delivery_note",
    "fieldtype": "Check",
-   "label": "Import Delivery Notes from Shopify on Shipment"
+   "label": "Create Delivery Note when an order is marked as fulfilled in Shopify"
   },
   {
    "depends_on": "eval:doc.sync_delivery_note==1",
@@ -204,7 +204,7 @@
    "default": "0",
    "fieldname": "sync_sales_invoice",
    "fieldtype": "Check",
-   "label": "Import Sales Invoice from Shopify if Payment is marked"
+   "label": "Create Sales Invoice and Payment Entry when an order is marked as paid in Shopify"
   },
   {
    "depends_on": "eval:doc.sync_sales_invoice==1",


### PR DESCRIPTION
fix (UX): better wordings for Shopify order sync setting Changed wordings on Shopify order sync setting page as below:

For delivery notes:
Current: Import Delivery Notes from Shopify on Shipment New: Create Delivery Note when an order is marked as fulfilled in Shopify

For sales invoices:
Current: Import Sales Invoice from Shopify if Payment is marked New: Create Sales Invoice and Payment Entry when an order is marked as paid in Shopify

Reason for change: 
* There is no "import" of sales invoices and delivery happening as part of this syncing. 
* Exact statuses as seen in Shopify "paid" and "fulfilled" instead of "on shipment" and "payment is marked"