### PR TITLE
feat: Enable partial fulfillment for Shopify Order

### DIFF
--- a/ecommerce_integrations/shopify/constants.py
+++ b/ecommerce_integrations/shopify/constants.py
@@ -13,6 +13,7 @@ WEBHOOK_EVENTS = [
 	"orders/paid",
 	"orders/fulfilled",
 	"orders/cancelled",
+	"orders/partially_fulfilled",
 ]
 
 EVENT_MAPPER = {
@@ -20,6 +21,7 @@ EVENT_MAPPER = {
 	"orders/paid": "ecommerce_integrations.shopify.invoice.prepare_sales_invoice",
 	"orders/fulfilled": "ecommerce_integrations.shopify.fulfillment.prepare_delivery_note",
 	"orders/cancelled": "ecommerce_integrations.shopify.order.cancel_order",
+	"orders/partially_fulfilled": "ecommerce_integrations.shopify.fulfillment.prepare_delivery_note",
 }
 
 SHOPIFY_VARIANTS_ATTR_LIST = ["option1", "option2", "option3"]


### PR DESCRIPTION
### ISSUE:
In the current workflow, when an order is fulfilled in Shopify across multiple fulfillments, it triggers the creation of delivery notes in ERPNext only after the entire order is fulfilled. All delivery notes are created at once. There is no way to keep track of partial fulfillments in ERPNext (which in some cases is required for partial billing against DNs).

### SOLUTION:
Create and register a new webhook called "orders/partially_fulfilled" and map it using the event mapper. Creation of Delivery Notes is handled by the "prepare_delivery_note" method.

**Note:** For existing installations, users might need to disable and re-enable the Shopify setting to activate re-registration of webhooks.

Fixes Issue #207 (https://github.com/frappe/ecommerce_integrations/issues/207)