### PR TITLE
fix: misleading "success" message for DN when SO doesn't exist

### DIFF
--- a/ecommerce_integrations/shopify/fulfillment.py
+++ b/ecommerce_integrations/shopify/fulfillment.py
@@ -23,7 +23,9 @@ def prepare_delivery_note(payload, request_id=None):
 		sales_order = get_sales_order(cstr(order["id"]))
 		if sales_order:
 			create_delivery_note(order, setting, sales_order)
-		create_shopify_log(status="Success")
+			create_shopify_log(status="Success")
+		else:
+			create_shopify_log(status="Invalid", message="Sales Order not found for syncing delivery note.")
 	except Exception as e:
 		create_shopify_log(status="Error", exception=e, rollback=True)
 


### PR DESCRIPTION
## ISSUE

Currently, when an order in Shopify is marked as fulfilled, it triggers the creation of a Delivery Note against the synced Sales Order in ERPNext. But, when the Sales Order is missing in ERPNext, this still triggers the creation of a Delivery Note and shows a success message in the Log. Ideally, it should check if Sales Order is present before creating the Delivery Note and if the Sales Order is not present, it should not create the Delivery Note and show the status accordingly in logs.

## SOLUTION

Implemented an if-else logic block to check if the Sales Order exists before creation of Delivery Note. If the Sales Order is missing, it will show "Invalid: Sales Order not found for syncing delivery note" message in the logs.