### PR TITLE
feat(shopify): ability to generate invoice on fulfilment

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
@@ -31,6 +31,7 @@
   "sync_delivery_note",
   "delivery_note_series",
   "sync_sales_invoice",
+  "sync_cod_invoices",
   "sales_invoice_series",
   "section_break_22",
   "html_16",
@@ -347,12 +348,18 @@
    "fieldname": "sync_new_item_as_active",
    "fieldtype": "Check",
    "label": "Sync New Items as Active"
+  },
+  {
+   "default": "0",
+   "fieldname": "sync_cod_invoices",
+   "fieldtype": "Check",
+   "label": "Import Sales Invoice from Shopify if Fulfillment is created"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-11-01 16:09:42.685577",
+ "modified": "2023-01-25 17:59:13.943796",
  "modified_by": "Administrator",
  "module": "shopify",
  "name": "Shopify Setting",

--- a/ecommerce_integrations/shopify/fulfillment.py
+++ b/ecommerce_integrations/shopify/fulfillment.py
@@ -1,6 +1,8 @@
+import json
+
 import frappe
 from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
-from frappe.utils import cint, cstr, getdate
+from frappe.utils import cint, cstr, flt, getdate
 
 from ecommerce_integrations.shopify.constants import (
 	FULLFILLMENT_ID_FIELD,
@@ -8,7 +10,12 @@ from ecommerce_integrations.shopify.constants import (
 	ORDER_NUMBER_FIELD,
 	SETTING_DOCTYPE,
 )
-from ecommerce_integrations.shopify.order import get_sales_order
+from ecommerce_integrations.shopify.order import (
+	get_sales_order,
+	get_tax_account_description,
+	get_tax_account_head,
+)
+from ecommerce_integrations.shopify.product import get_item_code
 from ecommerce_integrations.shopify.utils import create_shopify_log
 
 
@@ -52,6 +59,9 @@ def create_delivery_note(shopify_order, setting, so):
 			dn.items = get_fulfillment_items(
 				dn.items, fulfillment.get("line_items"), fulfillment.get("location_id")
 			)
+			dn.taxes = []
+			for tax in get_dn_taxes(fulfillment, setting):
+				dn.append("taxes", tax)
 			dn.flags.ignore_mandatory = True
 			dn.save()
 			dn.submit()
@@ -68,9 +78,6 @@ def create_delivery_note(shopify_order, setting, so):
 
 
 def get_fulfillment_items(dn_items, fulfillment_items, location_id=None):
-	# local import to avoid circular imports
-	from ecommerce_integrations.shopify.product import get_item_code
-
 	setting = frappe.get_cached_doc(SETTING_DOCTYPE)
 	wh_map = setting.get_integration_to_erpnext_wh_mapping()
 	warehouse = wh_map.get(str(location_id)) or setting.warehouse
@@ -81,3 +88,31 @@ def get_fulfillment_items(dn_items, fulfillment_items, location_id=None):
 		for dn_item in dn_items
 		if get_item_code(item) == dn_item.item_code
 	]
+
+
+def get_dn_taxes(fulfillment, setting):
+	taxes = []
+	line_items = fulfillment.get("line_items")
+
+	for line_item in line_items:
+		item_code = get_item_code(line_item)
+		for tax in line_item.get("tax_lines"):
+			tax_amt = (
+				flt(tax.get("rate", 0)) * flt(line_item.get("quantity", 0)) * flt(line_item.get("price", 0))
+			)
+			taxes.append(
+				{
+					"charge_type": "Actual",
+					"account_head": get_tax_account_head(tax),
+					"description": (
+						f"{get_tax_account_description(tax) or tax.get('title')} - {tax.get('rate') * 100.0:.2f}%"
+					),
+					"tax_amount": flt(tax_amt),
+					"included_in_print_rate": 0,
+					"cost_center": setting.cost_center,
+					"item_wise_tax_detail": json.dumps({item_code: [flt(tax.get("rate")) * 100, flt(tax_amt)]}),
+					"dont_recompute_tax": 1,
+				}
+			)
+
+	return taxes

--- a/ecommerce_integrations/shopify/invoice.py
+++ b/ecommerce_integrations/shopify/invoice.py
@@ -22,7 +22,10 @@ def prepare_sales_invoice(payload, request_id=None):
 	try:
 		sales_order = get_sales_order(cstr(order["id"]))
 		if sales_order:
-			create_sales_invoice(order, setting, sales_order)
+			payment = order.get("payment_terms", {}).get("payment_schedules", [])
+			posting_date = getdate(payment[0]["completed_at"]) if payment else nowdate()
+			create_sales_invoice(order, setting, sales_order, posting_date)
+			make_payment_entry_against_sales_invoice(cstr(order["id"]), setting, posting_date)
 			create_shopify_log(status="Success")
 		else:
 			create_shopify_log(status="Invalid", message="Sales Order not found for syncing sales invoice.")
@@ -30,17 +33,11 @@ def prepare_sales_invoice(payload, request_id=None):
 		create_shopify_log(status="Error", exception=e, rollback=True)
 
 
-def create_sales_invoice(shopify_order, setting, so):
-	if (
-		not frappe.db.get_value("Sales Invoice", {ORDER_ID_FIELD: shopify_order.get("id")}, "name")
-		and so.docstatus == 1
-		and not so.per_billed
-		and cint(setting.sync_sales_invoice)
-	):
-
-		posting_date = getdate(shopify_order.get("created_at")) or nowdate()
-
+def create_sales_invoice(shopify_order, setting, so, posting_date):
+	if so.docstatus == 1 and cint(setting.sync_sales_invoice):
 		sales_invoice = make_sales_invoice(so.name, ignore_permissions=True)
+		if not sales_invoice.items:
+			return
 		sales_invoice.set(ORDER_ID_FIELD, str(shopify_order.get("id")))
 		sales_invoice.set(ORDER_NUMBER_FIELD, shopify_order.get("name"))
 		sales_invoice.set_posting_time = 1
@@ -51,8 +48,6 @@ def create_sales_invoice(shopify_order, setting, so):
 		set_cost_center(sales_invoice.items, setting.cost_center)
 		sales_invoice.insert(ignore_mandatory=True)
 		sales_invoice.submit()
-		if sales_invoice.grand_total > 0:
-			make_payament_entry_against_sales_invoice(sales_invoice, setting, posting_date)
 
 		if shopify_order.get("note"):
 			sales_invoice.add_comment(text=f"Order Note: {shopify_order.get('note')}")
@@ -63,13 +58,45 @@ def set_cost_center(items, cost_center):
 		item.cost_center = cost_center
 
 
-def make_payament_entry_against_sales_invoice(doc, setting, posting_date=None):
+def make_payment_entry_against_sales_invoice(order_id, setting, posting_date=None):
 	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
-	payment_entry = get_payment_entry(doc.doctype, doc.name, bank_account=setting.cash_bank_account)
-	payment_entry.flags.ignore_mandatory = True
-	payment_entry.reference_no = doc.name
-	payment_entry.posting_date = posting_date or nowdate()
-	payment_entry.reference_date = posting_date or nowdate()
-	payment_entry.insert(ignore_permissions=True)
-	payment_entry.submit()
+	invoices = frappe.db.get_all(
+		"Sales Invoice",
+		filters={ORDER_ID_FIELD: order_id, "docstatus": 1},
+		fields=["name", "due_date", "grand_total", "outstanding_amount"],
+	)
+
+	if not invoices:
+		frappe.throw(frappe._("Invoices not synced to mark payment."))
+
+	payment_entry = None
+
+	for inv in invoices:
+		if not payment_entry:
+			payment_entry = get_payment_entry(
+				"Sales Invoice", inv.name, bank_account=setting.cash_bank_account
+			)
+			continue
+
+		payment_entry.append(
+			"references",
+			{
+				"reference_doctype": "Sales Invoice",
+				"reference_name": inv.name,
+				"bill_no": "",
+				"due_date": inv.due_date,
+				"total_amount": inv.grand_total,
+				"outstanding_amount": inv.outstanding_amount,
+				"allocated_amount": inv.outstanding_amount,
+			},
+		)
+		payment_entry.paid_amount += inv.outstanding_amount
+
+	if payment_entry:
+		payment_entry.flags.ignore_mandatory = True
+		payment_entry.reference_no = order_id
+		payment_entry.posting_date = posting_date or nowdate()
+		payment_entry.reference_date = posting_date or nowdate()
+		payment_entry.insert(ignore_permissions=True)
+		payment_entry.submit()

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -211,7 +211,7 @@ def get_order_taxes(shopify_order, setting):
 
 	taxes = update_taxes_with_shipping_lines(
 		taxes,
-		shopify_order.get("shipping_lines"),
+		shopify_order.get("shipping_lines", []),
 		setting,
 		taxes_inclusive=shopify_order.get("taxes_included"),
 	)


### PR DESCRIPTION
Changes from this PR:

1. Each fulfillment will create individual sales invoices (required in case of COD).
2. Recalculates taxes table in Delivery Note.
3. Clubbed Payment Entry for all invoices.

https://user-images.githubusercontent.com/52111700/214571950-3c654dec-325f-42de-b206-7542a729519f.mp4
