### PR TITLE
fix(shopify): item wise tax detail missing on shipping lines

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -220,7 +220,9 @@ def get_order_taxes(shopify_order, setting, items):
 		taxes = consolidate_order_taxes(taxes)
 
 	for row in taxes:
-		row["item_wise_tax_detail"] = json.dumps(row["item_wise_tax_detail"])
+		tax_detail = row.get("item_wise_tax_detail")
+		if isinstance(tax_detail, dict):
+			row["item_wise_tax_detail"] = json.dumps(tax_detail)
 
 	return taxes
 


### PR DESCRIPTION
caused by https://github.com/frappe/ecommerce_integrations/pull/229

```
Traceback (most recent call last):
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 49, in sync_sales_order
    create_order(order, setting)
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 61, in create_order
    so = create_sales_order(order, setting, company)
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 96, in create_sales_order
    taxes = get_order_taxes(shopify_order, setting, items)
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 223, in get_order_taxes
    row["item_wise_tax_detail"] = json.dumps(row["item_wise_tax_detail"])
KeyError: 'item_wise_tax_detail'
```
