### PR TITLE
feat: (Uni-commerce) generate Delivery Note and sync item fields

### DIFF
--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -148,6 +148,7 @@ scheduler_events = {
 		"*/5 * * * *": [
 			"ecommerce_integrations.unicommerce.order.sync_new_orders",
 			"ecommerce_integrations.unicommerce.inventory.update_inventory_on_unicommerce",
+			"ecommerce_integrations.unicommerce.delivery_note.prepare_delivery_note",
 		],
 	},
 }

--- a/ecommerce_integrations/unicommerce/constants.py
+++ b/ecommerce_integrations/unicommerce/constants.py
@@ -33,6 +33,7 @@ ITEM_BATCH_GROUP_FIELD = "unicommerce_batch_group_code"
 SHIPPING_PACKAGE_STATUS_FIELD = "unicommerce_shipping_package_status"
 IS_COD_CHECKBOX = "unicommerce_is_cod"
 SHIPPING_METHOD_FIELD = "unicommerce_shipping_method"
+UNICOMMERCE_SHIPPING_ID = "unicommerce_shipment_id"
 PICKLIST_ORDER_DETAILS_FIELD = "order_details"
 
 GRN_STOCK_ENTRY_TYPE = "GRN on Unicommerce"

--- a/ecommerce_integrations/unicommerce/delivery_note.py
+++ b/ecommerce_integrations/unicommerce/delivery_note.py
@@ -1,0 +1,99 @@
+import frappe
+
+from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient
+from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
+from ecommerce_integrations.unicommerce.utils import create_unicommerce_log
+
+
+@frappe.whitelist()
+def prepare_delivery_note():
+	try:
+		settings = frappe.get_cached_doc(SETTINGS_DOCTYPE)
+		if not settings.delivery_note:
+			return
+
+		client = UnicommerceAPIClient()
+
+		days_to_sync = min(settings.get("order_status_days") or 2, 14)
+		minutes = days_to_sync * 24 * 60
+
+		# find all Facilities
+		enabled_facilities = list(settings.get_integration_to_erpnext_wh_mapping().keys())
+		enabled_channels = frappe.db.get_list(
+			"Unicommerce Channel", filters={"enabled": 1}, pluck="channel_id"
+		)
+
+		for facility in enabled_facilities:
+			updated_packages = client.search_shipping_packages(
+				updated_since=minutes, facility_code=facility
+			)
+			valid_packages = [p for p in updated_packages if p.get("channel") in enabled_channels]
+			if not valid_packages:
+				continue
+			shipped_packages = [p for p in valid_packages if p["status"] in ["DISPATCHED"]]
+			for order in shipped_packages:
+				if not frappe.db.exists(
+					"Delivery Note", {"unicommerce_shipment_id": order["code"]}, "name"
+				) and frappe.db.exists("Sales Order", {ORDER_CODE_FIELD: order["saleOrderCode"]}):
+					sales_order = frappe.get_doc("Sales Order", {ORDER_CODE_FIELD: order["saleOrderCode"]})
+					if frappe.db.exists(
+						"Sales Invoice", {"unicommerce_order_code": sales_order.unicommerce_order_code}
+					):
+						sales_invoice = frappe.get_doc(
+							"Sales Invoice", {"unicommerce_order_code": sales_order.unicommerce_order_code}
+						)
+						create_delivery_note(sales_order, sales_invoice)
+	except Exception as e:
+		create_unicommerce_log(status="Error", exception=e, rollback=True)
+
+
+def create_delivery_note(so, sales_invoice):
+	try:
+		# Create the delivery note
+		from frappe.model.mapper import make_mapped_doc
+
+		res = make_mapped_doc(
+			method="erpnext.selling.doctype.sales_order.sales_order.make_delivery_note", source_name=so.name
+		)
+		res.update({"items": []})
+		for item in sales_invoice.items:
+			res.append(
+				"items",
+				{
+					"item_code": item.item_code,
+					"item_name": item.item_name,
+					"description": item.description,
+					"qty": item.qty,
+					"uom": item.uom,
+					"rate": item.rate,
+					"amount": item.amount,
+					"warehouse": item.warehouse,
+					"against_sales_order": item.sales_order,
+					"batch_no": item.batch_no,
+					"so_detail": item.so_detail,
+				},
+			)
+		for item in sales_invoice.taxes:
+			res.append(
+				"taxes",
+				{
+					"charge_type": item.charge_type,
+					"account_head": item.account_head,
+					"tax_amount": item.tax_amount,
+					"description": item.description,
+					"item_wise_tax_detail": item.item_wise_tax_detail,
+					"dont_recompute_tax": item.dont_recompute_tax,
+				},
+			)
+		res.unicommerce_order_code = sales_invoice.unicommerce_order_code
+		res.unicommerce_shipment_id = sales_invoice.unicommerce_shipping_package_code
+		res.save()
+		res.submit()
+		log = create_unicommerce_log(method="create_delevery_note", make_new=True)
+		frappe.flags.request_id = log.name
+	except Exception as e:
+		create_unicommerce_log(status="Error", exception=e, rollback=True)
+	else:
+		create_unicommerce_log(status="Success")
+		frappe.flags.request_id = None
+		return res

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.json
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.json
@@ -29,6 +29,8 @@
   "sales_order_series",
   "sales_invoice_series",
   "order_status_days",
+  "delivery_note_settings_section",
+  "delivery_note",
   "inventory_sync_settings_section",
   "enable_inventory_sync",
   "inventory_sync_frequency",
@@ -249,12 +251,23 @@
    "fieldname": "vendor_code",
    "fieldtype": "Data",
    "label": "Vendor Code"
+  },
+  {
+   "fieldname": "delivery_note_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Delivery Note Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "delivery_note",
+   "fieldtype": "Check",
+   "label": "Import Delivery Notes from Unicommerce on Shipment"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-02-07 14:11:34.599710",
+ "modified": "2023-05-02 14:04:26.684256",
  "modified_by": "Administrator",
  "module": "unicommerce",
  "name": "Unicommerce Settings",

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
@@ -42,6 +42,7 @@ from ecommerce_integrations.unicommerce.constants import (
 	SHIPPING_PACKAGE_STATUS_FIELD,
 	SHIPPING_PROVIDER_CODE,
 	TRACKING_CODE_FIELD,
+	UNICOMMERCE_SHIPPING_ID,
 )
 from ecommerce_integrations.unicommerce.utils import create_unicommerce_log
 
@@ -199,6 +200,15 @@ def setup_custom_fields(update=True):
 				label="Unicommerce Details",
 				fieldtype="Section Break",
 				insert_after="against_income_account",
+				collapsible=1,
+			),
+		],
+		"Delivery Note": [
+			dict(
+				fieldname="unicommerce_section",
+				label="Unicommerce Details",
+				fieldtype="Section Break",
+				insert_after="instructions",
 				collapsible=1,
 			),
 		],
@@ -426,6 +436,22 @@ def setup_custom_fields(update=True):
 				label="Unicommerce Return Code",
 				fieldtype="Small Text",
 				insert_after=IS_COD_CHECKBOX,
+				read_only=1,
+			),
+		],
+		"Delivery Note": [
+			dict(
+				fieldname=ORDER_CODE_FIELD,
+				label="Unicommerce Order No",
+				fieldtype="Data",
+				insert_after="unicommerce_section",
+				read_only=1,
+			),
+			dict(
+				fieldname=UNICOMMERCE_SHIPPING_ID,
+				label="Unicommerce Shipment Id",
+				fieldtype="Data",
+				insert_after=ORDER_CODE_FIELD,
 				read_only=1,
 			),
 		],

--- a/ecommerce_integrations/unicommerce/invoice.py
+++ b/ecommerce_integrations/unicommerce/invoice.py
@@ -381,7 +381,7 @@ def create_sales_invoice(
 	si.naming_series = channel_config.sales_invoice_series or settings.sales_invoice_series
 	si.delivery_date = so.delivery_date
 	si.ignore_pricing_rule = 1
-	si.update_stock = update_stock
+	si.update_stock = False if settings.delivery_note else update_stock
 	si.flags.raw_data = si_data
 	si.insert()
 

--- a/ecommerce_integrations/unicommerce/product.py
+++ b/ecommerce_integrations/unicommerce/product.py
@@ -39,6 +39,8 @@ UNI_TO_ERPNEXT_ITEM_MAPPING = {
 	"width": ITEM_WIDTH_FIELD,
 	"height": ITEM_HEIGHT_FIELD,
 	"batchGroupCode": ITEM_BATCH_GROUP_FIELD,
+	"maxRetailPrice": "standard_rate",
+	"costPrice": "valuation_rate",
 }
 
 ERPNEXT_TO_UNI_ITEM_MAPPING = {v: k for k, v in UNI_TO_ERPNEXT_ITEM_MAPPING.items()}
@@ -287,6 +289,9 @@ def _build_unicommerce_item(item_code: ItemCode) -> JsonDict:
 	)
 	# append site prefix to image url
 	item_json["imageUrl"] = get_url(item.image)
+	item_json["maxRetailPrice"] = item.standard_rate
+	item_json["description"] = frappe.utils.strip_html_tags(item.description)
+	item_json["costPrice"] = item.valuation_rate
 
 	return item_json
 

--- a/ecommerce_integrations/unicommerce/tests/test_delivery_note.py
+++ b/ecommerce_integrations/unicommerce/tests/test_delivery_note.py
@@ -1,0 +1,65 @@
+import base64
+import unittest
+
+import frappe
+import responses
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+from ecommerce_integrations.unicommerce.constants import (
+	FACILITY_CODE_FIELD,
+	INVOICE_CODE_FIELD,
+	ORDER_CODE_FIELD,
+	SHIPPING_PACKAGE_CODE_FIELD,
+)
+from ecommerce_integrations.unicommerce.delivery_note import create_delivery_note
+from ecommerce_integrations.unicommerce.invoice import bulk_generate_invoices, create_sales_invoice
+from ecommerce_integrations.unicommerce.order import create_order
+from ecommerce_integrations.unicommerce.tests.test_client import TestCaseApiClient
+
+
+class TestDeliveryNote(TestCaseApiClient):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+
+	def test_create_invoice_and_delivery_note(self):
+		"""Use mocked invoice json to create and assert synced fields"""
+		from ecommerce_integrations.unicommerce import invoice
+
+		# HACK to allow invoicing test
+		invoice.INVOICED_STATE.append("CREATED")
+		self.responses.add(
+			responses.POST,
+			"https://demostaging.unicommerce.com/services/rest/v1/oms/shippingPackage/createInvoiceAndAllocateShippingProvider",
+			status=200,
+			json=self.load_fixture("create_invoice_and_assign_shipper"),
+			match=[responses.json_params_matcher({"shippingPackageCode": "TEST00949"})],
+		)
+		self.responses.add(
+			responses.POST,
+			"https://demostaging.unicommerce.com/services/rest/v1/invoice/details/get",
+			status=200,
+			json=self.load_fixture("invoice-SDU0026"),
+			match=[responses.json_params_matcher({"shippingPackageCode": "TEST00949", "return": False})],
+		)
+		self.responses.add(
+			responses.GET,
+			"https://example.com",
+			status=200,
+			body=base64.b64decode(self.load_fixture("invoice_label_response")["label"]),
+		)
+
+		order = self.load_fixture("order-SO5906")["saleOrderDTO"]
+		so = create_order(order, client=self.client)
+		make_stock_entry(item_code="MC-100", qty=15, to_warehouse="Stores - WP", rate=42)
+
+		bulk_generate_invoices(sales_orders=[so.name], client=self.client)
+
+		sales_invoice_code = frappe.db.get_value("Sales Invoice", {INVOICE_CODE_FIELD: "SDU0026"})
+
+		if not sales_invoice_code:
+			self.fail("Sales invoice not generated")
+
+		si = frappe.get_doc("Sales Invoice", sales_invoice_code)
+		dn = create_delivery_note(so, si)
+		self.assertEqual(dn.unicommerce_order_code, so.unicommerce_order_code)


### PR DESCRIPTION
feat: (Uni-commerce) generate Delivery Note and sync item fields

We have implemented the requested functionality as per the client's specifications. 
Specifically, when the designated checkbox is clicked, the system will automatically import Delivery Notes from Uni-commerce into ERPNEXT upon shipment.

![image](https://user-images.githubusercontent.com/49873594/235635940-6508161c-cbe1-490f-a66c-132f9c65d79f.png)


https://komododecks.com/recordings/uXlkZvS50jHgA3oxK98y