### PR TITLE
fix:API verions not found in Shopify

### DIFF
--- a/ecommerce_integrations/shopify/constants.py
+++ b/ecommerce_integrations/shopify/constants.py
@@ -6,7 +6,7 @@ MODULE_NAME = "shopify"
 SETTING_DOCTYPE = "Shopify Setting"
 OLD_SETTINGS_DOCTYPE = "Shopify Settings"
 
-API_VERSION = "2022-04"
+API_VERSION = "2022-10"
 
 WEBHOOK_EVENTS = [
 	"orders/create",


### PR DESCRIPTION
Shoipify removed the API version 22.04