### PR TITLE
fix: add filters for `Warehouse` and `Account Group`

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
@@ -2,7 +2,27 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Amazon SP API Settings', {
-	// refresh: function(frm) {
+	refresh(frm) {
+		frm.trigger("set_queries");
+	},
 
-	// }
+	set_queries(frm) {
+		frm.set_query("warehouse", () => {
+			return {
+				filters: {
+					"is_group": 0,
+					"company": frm.doc.company,
+				}
+			};
+		});
+
+		frm.set_query("market_place_account_group", () => {
+			return {
+				filters: {
+					"is_group": 1,
+					"company": frm.doc.company,
+				}
+			};
+		});
+	}
 });


### PR DESCRIPTION
Filters for `Warehouse` and `Account Group` in Amazon SP API Settings.

Before:

![image](https://github.com/frappe/ecommerce_integrations/assets/63660334/1f5b5086-9079-4879-8ae8-a9d414adbbba)

![image](https://github.com/frappe/ecommerce_integrations/assets/63660334/ae2e4cfc-a10e-41fb-8c3f-0aa319212b57)

After:

![image](https://github.com/frappe/ecommerce_integrations/assets/63660334/7e5b497c-53fd-4c15-af2b-74c1df3ad855)

![image](https://github.com/frappe/ecommerce_integrations/assets/63660334/091c0c04-da47-47ac-a9e3-171e408dfe46)

