### PR TITLE
feat: Amazon - ERPNext Item field map

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_fields_map/amazon_fields_map.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_fields_map/amazon_fields_map.json
@@ -1,0 +1,57 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-07-28 21:59:03.809862",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "amazon_field",
+  "column_break_eww7",
+  "item_field",
+  "use_to_find_item_code"
+ ],
+ "fields": [
+  {
+   "fieldname": "amazon_field",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Amazon Field",
+   "read_only": 1,
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "item_field",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Field",
+   "mandatory_depends_on": "eval: doc.use_to_find_item_code",
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_eww7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_to_find_item_code",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Use To Find Item Code"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-07-29 09:31:42.507679",
+ "modified_by": "Administrator",
+ "module": "Amazon",
+ "name": "Amazon Fields Map",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/ecommerce_integrations/amazon/doctype/amazon_fields_map/amazon_fields_map.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_fields_map/amazon_fields_map.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AmazonFieldsMap(Document):
+	pass

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -3,18 +3,30 @@
 
 
 import time
-import urllib.request
+import urllib
 
 import dateutil
 import frappe
 from frappe import _
 
-import ecommerce_integrations.amazon.doctype.amazon_sp_api_settings.amazon_sp_api as sp_api
+from ecommerce_integrations.amazon.doctype.amazon_sp_api_settings.amazon_sp_api import (
+	SPAPI,
+	CatalogItems,
+	Finances,
+	Orders,
+	SPAPIError,
+)
+from ecommerce_integrations.amazon.doctype.amazon_sp_api_settings.amazon_sp_api_settings import (
+	AmazonSPAPISettings,
+)
 
 
-class AmazonRepository:
-	def __init__(self, amz_setting_name) -> None:
-		self.amz_setting = frappe.get_doc("Amazon SP API Settings", amz_setting_name)
+class AmazonBaseRepository:
+	def __init__(self, amz_setting: str | AmazonSPAPISettings) -> None:
+		if isinstance(amz_setting, str):
+			amz_setting = frappe.get_doc("Amazon SP API Settings", amz_setting)
+
+		self.amz_setting = amz_setting
 		self.instance_params = dict(
 			iam_arn=self.amz_setting.iam_arn,
 			client_id=self.amz_setting.client_id,
@@ -25,14 +37,13 @@ class AmazonRepository:
 			country_code=self.amz_setting.country,
 		)
 
-	# Helper Methods
-	def return_as_list(self, input):
+	def return_as_list(self, input) -> list:
 		if isinstance(input, list):
 			return input
 		else:
 			return [input]
 
-	def call_sp_api_method(self, sp_api_method, **kwargs):
+	def call_sp_api_method(self, sp_api_method, **kwargs) -> dict:
 		errors = {}
 		max_retries = self.amz_setting.max_retry_limit
 
@@ -40,9 +51,10 @@ class AmazonRepository:
 			try:
 				result = sp_api_method(**kwargs)
 				return result.get("payload")
-			except sp_api.SPAPIError as e:
+			except SPAPIError as e:
 				if e.error not in errors:
 					errors[e.error] = e.error_description
+
 				time.sleep(1)
 				continue
 
@@ -50,7 +62,7 @@ class AmazonRepository:
 			msg = f"<b>Error:</b> {error}<br/><b>Error Description:</b> {errors.get(error)}"
 			frappe.msgprint(msg, alert=True, indicator="red")
 			frappe.log_error(
-				message=f"{error}: {errors.get(error)}", title=f'Method "{sp_api_method.__name__}" failed'
+				message=f"{error}: {errors.get(error)}", title=f'Method "{sp_api_method.__name__}" failed',
 			)
 
 		self.amz_setting.enable_sync = 0
@@ -60,11 +72,15 @@ class AmazonRepository:
 			_("Scheduled sync has been temporarily disabled because maximum retries have been exceeded!")
 		)
 
-	# Finances Section
-	def get_finances_instance(self):
-		return sp_api.Finances(**self.instance_params)
 
-	def get_account(self, name):
+class AmazonFinancesRepository(AmazonBaseRepository):
+	def __init__(self, amz_setting: str | AmazonSPAPISettings) -> None:
+		super().__init__(amz_setting)
+
+	def get_finances_instance(self) -> Finances:
+		return Finances(**self.instance_params)
+
+	def get_account(self, name) -> str:
 		account_name = frappe.db.get_value("Account", {"account_name": "Amazon {0}".format(name)})
 
 		if not account_name:
@@ -77,7 +93,7 @@ class AmazonRepository:
 
 		return account_name
 
-	def get_charges_and_fees(self, order_id):
+	def get_charges_and_fees(self, order_id) -> dict:
 		finances = self.get_finances_instance()
 		financial_events_payload = self.call_sp_api_method(
 			sp_api_method=finances.list_financial_events_by_order_id, order_id=order_id
@@ -86,23 +102,19 @@ class AmazonRepository:
 		charges_and_fees = {"charges": [], "fees": []}
 
 		while True:
-
 			shipment_event_list = financial_events_payload.get("FinancialEvents", {}).get(
 				"ShipmentEventList", []
 			)
 			next_token = financial_events_payload.get("NextToken")
 
 			for shipment_event in shipment_event_list:
-
 				if shipment_event:
-
 					for shipment_item in shipment_event.get("ShipmentItemList", []):
 						charges = shipment_item.get("ItemChargeList", [])
 						fees = shipment_item.get("ItemFeeList", [])
 						seller_sku = shipment_item.get("SellerSKU")
 
 						for charge in charges:
-
 							charge_type = charge.get("ChargeType")
 							amount = charge.get("ChargeAmount", {}).get("CurrencyAmount", 0)
 
@@ -118,7 +130,6 @@ class AmazonRepository:
 								)
 
 						for fee in fees:
-
 							fee_type = fee.get("FeeType")
 							amount = fee.get("FeeAmount", {}).get("CurrencyAmount", 0)
 
@@ -144,96 +155,132 @@ class AmazonRepository:
 
 		return charges_and_fees
 
-	# Orders Section
-	def get_orders_instance(self):
-		return sp_api.Orders(**self.instance_params)
 
-	def create_customer(self, order):
-		order_customer_name = ""
-		buyer_info = order.get("BuyerInfo")
+class AmazonOrdersRepository(AmazonBaseRepository):
+	def __init__(self, amz_setting: str | AmazonSPAPISettings) -> None:
+		super().__init__(amz_setting)
 
-		if buyer_info and buyer_info.get("BuyerName"):
-			order_customer_name = buyer_info.get("BuyerName")
+	def get_orders_instance(self) -> Orders:
+		return Orders(**self.instance_params)
+
+	def create_item(self, order_item) -> str:
+		def create_item_group(amazon_item) -> str:
+			item_group_name = amazon_item.get("AttributeSets")[0].get("ProductGroup")
+
+			if item_group_name:
+				item_group = frappe.db.get_value("Item Group", filters={"item_group_name": item_group_name})
+
+				if not item_group:
+					new_item_group = frappe.new_doc("Item Group")
+					new_item_group.item_group_name = item_group_name
+					new_item_group.parent_item_group = self.amz_setting.parent_item_group
+					new_item_group.insert()
+					return new_item_group.item_group_name
+				return item_group
+
+			raise (KeyError("ProductGroup"))
+
+		def create_brand(amazon_item) -> str:
+			brand_name = amazon_item.get("AttributeSets")[0].get("Brand")
+
+			if not brand_name:
+				return
+
+			existing_brand = frappe.db.get_value("Brand", filters={"brand": brand_name})
+
+			if not existing_brand:
+				brand = frappe.new_doc("Brand")
+				brand.brand = brand_name
+				brand.insert()
+				return brand.brand
+			return existing_brand
+
+		def create_manufacturer(amazon_item) -> str:
+			manufacturer_name = amazon_item.get("AttributeSets")[0].get("Manufacturer")
+
+			if not manufacturer_name:
+				return
+
+			existing_manufacturer = frappe.db.get_value(
+				"Manufacturer", filters={"short_name": manufacturer_name}
+			)
+
+			if not existing_manufacturer:
+				manufacturer = frappe.new_doc("Manufacturer")
+				manufacturer.short_name = manufacturer_name
+				manufacturer.insert()
+				return manufacturer.short_name
+			return existing_manufacturer
+
+		def create_item_price(amazon_item, item_code) -> None:
+			item_price = frappe.new_doc("Item Price")
+			item_price.price_list = self.amz_setting.price_list
+			item_price.price_list_rate = (
+				amazon_item.get("AttributeSets")[0].get("ListPrice", {}).get("Amount") or 0
+			)
+			item_price.item_code = item_code
+			item_price.insert()
+
+		def create_ecommerce_item(order_item, item_code) -> None:
+			ecommerce_item = frappe.new_doc("Ecommerce Item")
+			ecommerce_item.integration = frappe.get_meta("Amazon SP API Settings").module
+			ecommerce_item.erpnext_item_code = item_code
+			ecommerce_item.integration_item_code = order_item["ASIN"]
+			ecommerce_item.sku = order_item["SellerSKU"]
+			ecommerce_item.insert(ignore_permissions=True)
+
+		acir = AmazonCatalogItemsRepository(self.amz_setting)
+		catalog_items = acir.get_catalog_items_instance()
+		amazon_item = catalog_items.get_catalog_item(order_item["ASIN"])["payload"]
+
+		item = frappe.new_doc("Item")
+
+		for field_map in self.amz_setting.amazon_fields_map:
+			if field_map.use_to_find_item_code:
+				item.item_code = order_item[field_map.amazon_field]
+
+			if field_map.item_field:
+				setattr(item, field_map.item_field, order_item[field_map.amazon_field])
+
+		item.item_group = create_item_group(amazon_item)
+		item.brand = create_brand(amazon_item)
+		item.manufacturer = create_manufacturer(amazon_item)
+		item.insert(ignore_permissions=True)
+
+		create_item_price(amazon_item, item.item_code)
+		create_ecommerce_item(order_item, item.item_code)
+
+		return item.item_code
+
+	def get_item_code(self, order_item) -> str:
+		for field_map in self.amz_setting.amazon_fields_map:
+			if field_map.use_to_find_item_code:
+				item_code = frappe.db.get_value(
+					"Item",
+					filters={field_map.item_field: order_item[field_map.amazon_field]},
+					fieldname="item_code",
+				)
+
+				if item_code:
+					return item_code
+				elif not self.amz_setting.create_item_if_not_exists:
+					field_label = frappe.get_meta("Item").get_label(field_map.item_field)
+					frappe.throw(
+						_("Item not found with {0} ({1}) = {2}.").format(
+							frappe.bold(field_label),
+							field_map.item_field,
+							frappe.bold(order_item[field_map.amazon_field]),
+						)
+					)
+
+				break
 		else:
-			order_customer_name = f"Buyer - {order.get('AmazonOrderId')}"
+			frappe.throw(_("At least one field must be selected to find the item code."))
 
-		existing_customer_name = frappe.db.get_value(
-			"Customer", filters={"name": order_customer_name}, fieldname="name"
-		)
+		item_code = self.create_item(order_item)
+		return item_code
 
-		if existing_customer_name:
-			filters = [
-				["Dynamic Link", "link_doctype", "=", "Customer"],
-				["Dynamic Link", "link_name", "=", existing_customer_name],
-				["Dynamic Link", "parenttype", "=", "Contact"],
-			]
-
-			existing_contacts = frappe.get_list("Contact", filters)
-
-			if not existing_contacts:
-				new_contact = frappe.new_doc("Contact")
-				new_contact.first_name = order_customer_name
-				new_contact.append("links", {"link_doctype": "Customer", "link_name": existing_customer_name})
-				new_contact.insert()
-
-			return existing_customer_name
-		else:
-			new_customer = frappe.new_doc("Customer")
-			new_customer.customer_name = order_customer_name
-			new_customer.customer_group = self.amz_setting.customer_group
-			new_customer.territory = self.amz_setting.territory
-			new_customer.customer_type = self.amz_setting.customer_type
-			new_customer.save()
-
-			new_contact = frappe.new_doc("Contact")
-			new_contact.first_name = order_customer_name
-			new_contact.append("links", {"link_doctype": "Customer", "link_name": new_customer.name})
-
-			new_contact.insert()
-
-			return new_customer.name
-
-	def create_address(self, order, customer_name):
-		shipping_address = order.get("ShippingAddress")
-
-		if not shipping_address:
-			return
-		else:
-			make_address = frappe.new_doc("Address")
-			make_address.address_line1 = shipping_address.get("AddressLine1", "Not Provided")
-			make_address.city = shipping_address.get("City", "Not Provided")
-			make_address.state = shipping_address.get("StateOrRegion").title()
-			make_address.pincode = shipping_address.get("PostalCode")
-
-			filters = [
-				["Dynamic Link", "link_doctype", "=", "Customer"],
-				["Dynamic Link", "link_name", "=", customer_name],
-				["Dynamic Link", "parenttype", "=", "Address"],
-			]
-			existing_address = frappe.get_list("Address", filters)
-
-			for address in existing_address:
-				address_doc = frappe.get_doc("Address", address["name"])
-				if (
-					address_doc.address_line1 == make_address.address_line1
-					and address_doc.pincode == make_address.pincode
-				):
-					return address
-
-			make_address.append("links", {"link_doctype": "Customer", "link_name": customer_name})
-			make_address.address_type = "Shipping"
-			make_address.insert()
-
-	def get_item_code(self, order_item):
-		asin = order_item.get("ASIN")
-
-		if asin:
-			if frappe.db.exists({"doctype": "Item", "item_code": asin}):
-				return asin
-		else:
-			raise KeyError("ASIN")
-
-	def get_order_items(self, order_id):
+	def get_order_items(self, order_id) -> list:
 		orders = self.get_orders_instance()
 		order_items_payload = self.call_sp_api_method(
 			sp_api_method=orders.get_order_items, order_id=order_id
@@ -243,79 +290,158 @@ class AmazonRepository:
 		warehouse = self.amz_setting.warehouse
 
 		while True:
-
 			order_items_list = order_items_payload.get("OrderItems")
 			next_token = order_items_payload.get("NextToken")
 
 			for order_item in order_items_list:
-				price = order_item.get("ItemPrice", {}).get("Amount", 0)
-
-				final_order_items.append(
-					{
-						"item_code": self.get_item_code(order_item),
-						"item_name": order_item.get("SellerSKU"),
-						"description": order_item.get("Title"),
-						"rate": price,
-						"qty": order_item.get("QuantityOrdered"),
-						"stock_uom": "Nos",
-						"warehouse": warehouse,
-						"conversion_factor": "1.0",
-					}
-				)
+				if order_item.get("QuantityOrdered") > 0:
+					final_order_items.append(
+						{
+							"item_code": self.get_item_code(order_item),
+							"item_name": order_item.get("SellerSKU"),
+							"description": order_item.get("Title"),
+							"rate": order_item.get("ItemPrice", {}).get("Amount", 0),
+							"qty": order_item.get("QuantityOrdered"),
+							"stock_uom": "Nos",
+							"warehouse": warehouse,
+							"conversion_factor": 1.0,
+						}
+					)
 
 			if not next_token:
 				break
 
 			order_items_payload = self.call_sp_api_method(
-				sp_api_method=orders.get_order_items, order_id=order_id, next_token=next_token
+				sp_api_method=orders.get_order_items, order_id=order_id, next_token=next_token,
 			)
 
 		return final_order_items
 
-	def create_sales_order(self, order):
-		customer_name = self.create_customer(order)
-		self.create_address(order, customer_name)
+	def create_sales_order(self, order) -> str | None:
+		def create_customer(order) -> str:
+			order_customer_name = ""
+			buyer_info = order.get("BuyerInfo")
+
+			if buyer_info and buyer_info.get("BuyerEmail"):
+				order_customer_name = buyer_info.get("BuyerEmail")
+			else:
+				order_customer_name = f"Buyer - {order.get('AmazonOrderId')}"
+
+			existing_customer_name = frappe.db.get_value(
+				"Customer", filters={"name": order_customer_name}, fieldname="name"
+			)
+
+			if existing_customer_name:
+				filters = [
+					["Dynamic Link", "link_doctype", "=", "Customer"],
+					["Dynamic Link", "link_name", "=", existing_customer_name],
+					["Dynamic Link", "parenttype", "=", "Contact"],
+				]
+
+				existing_contacts = frappe.get_list("Contact", filters)
+
+				if not existing_contacts:
+					new_contact = frappe.new_doc("Contact")
+					new_contact.first_name = order_customer_name
+					new_contact.append(
+						"links", {"link_doctype": "Customer", "link_name": existing_customer_name},
+					)
+					new_contact.insert()
+
+				return existing_customer_name
+			else:
+				new_customer = frappe.new_doc("Customer")
+				new_customer.customer_name = order_customer_name
+				new_customer.customer_group = self.amz_setting.customer_group
+				new_customer.territory = self.amz_setting.territory
+				new_customer.customer_type = self.amz_setting.customer_type
+				new_customer.save()
+
+				new_contact = frappe.new_doc("Contact")
+				new_contact.first_name = order_customer_name
+				new_contact.append("links", {"link_doctype": "Customer", "link_name": new_customer.name})
+
+				new_contact.insert()
+
+				return new_customer.name
+
+		def create_address(order, customer_name) -> str | None:
+			shipping_address = order.get("ShippingAddress")
+
+			if not shipping_address:
+				return
+			else:
+				make_address = frappe.new_doc("Address")
+				make_address.address_line1 = shipping_address.get("AddressLine1", "Not Provided")
+				make_address.city = shipping_address.get("City", "Not Provided")
+				make_address.state = shipping_address.get("StateOrRegion").title()
+				make_address.pincode = shipping_address.get("PostalCode")
+
+				filters = [
+					["Dynamic Link", "link_doctype", "=", "Customer"],
+					["Dynamic Link", "link_name", "=", customer_name],
+					["Dynamic Link", "parenttype", "=", "Address"],
+				]
+				existing_address = frappe.get_list("Address", filters)
+
+				for address in existing_address:
+					address_doc = frappe.get_doc("Address", address["name"])
+					if (
+						address_doc.address_line1 == make_address.address_line1
+						and address_doc.pincode == make_address.pincode
+					):
+						return address
+
+				make_address.append("links", {"link_doctype": "Customer", "link_name": customer_name})
+				make_address.address_type = "Shipping"
+				make_address.insert()
 
 		order_id = order.get("AmazonOrderId")
-		sales_order = frappe.db.get_value(
-			"Sales Order", filters={"amazon_order_id": order_id}, fieldname="name"
-		)
+		so = frappe.db.get_value("Sales Order", filters={"amazon_order_id": order_id}, fieldname="name")
 
-		if sales_order:
-			return sales_order
+		if so:
+			return so
 		else:
 			items = self.get_order_items(order_id)
+
+			if not items:
+				return
+
+			customer_name = create_customer(order)
+			create_address(order, customer_name)
+
 			delivery_date = dateutil.parser.parse(order.get("LatestShipDate")).strftime("%Y-%m-%d")
 			transaction_date = dateutil.parser.parse(order.get("PurchaseDate")).strftime("%Y-%m-%d")
 
-			sales_order = frappe.get_doc(
-				{
-					"doctype": "Sales Order",
-					"naming_series": "SO-",
-					"amazon_order_id": order_id,
-					"marketplace_id": order.get("MarketplaceId"),
-					"customer": customer_name,
-					"delivery_date": delivery_date,
-					"transaction_date": transaction_date,
-					"items": items,
-					"company": self.amz_setting.company,
-				}
-			)
+			so = frappe.new_doc("Sales Order")
+			so.amazon_order_id = order_id
+			so.marketplace_id = order.get("MarketplaceId")
+			so.customer = customer_name
+			so.delivery_date = delivery_date
+			so.transaction_date = transaction_date
+			so.company = self.amz_setting.company
+
+			for item in items:
+				so.append("items", item)
 
 			taxes_and_charges = self.amz_setting.taxes_charges
 
 			if taxes_and_charges:
-				charges_and_fees = self.get_charges_and_fees(order_id)
+				afr = AmazonFinancesRepository(self.amz_setting)
+				charges_and_fees = afr.get_charges_and_fees(order_id)
+
 				for charge in charges_and_fees.get("charges"):
-					sales_order.append("taxes", charge)
+					so.append("taxes", charge)
+
 				for fee in charges_and_fees.get("fees"):
-					sales_order.append("taxes", fee)
+					so.append("taxes", fee)
 
-			sales_order.insert(ignore_permissions=True)
-			sales_order.submit()
-			return sales_order.name
+			so.insert(ignore_permissions=True)
+			so.submit()
 
-	def get_orders(self, created_after):
+			return so.name
+
+	def get_orders(self, created_after) -> list:
 		orders = self.get_orders_instance()
 		order_statuses = [
 			"PendingAvailability",
@@ -340,7 +466,6 @@ class AmazonRepository:
 		sales_orders = []
 
 		while True:
-
 			orders_list = orders_payload.get("Orders")
 			next_token = orders_payload.get("NextToken")
 
@@ -349,195 +474,29 @@ class AmazonRepository:
 
 			for order in orders_list:
 				sales_order = self.create_sales_order(order)
-				sales_orders.append(sales_order)
+				if sales_order:
+					sales_orders.append(sales_order)
 
 			if not next_token:
 				break
 
 			orders_payload = self.call_sp_api_method(
-				sp_api_method=orders.get_orders, created_after=created_after, next_token=next_token
+				sp_api_method=orders.get_orders, created_after=created_after, next_token=next_token,
 			)
 
 		return sales_orders
 
-	# CatalogItems or Products Section
-	def get_catalog_items_instance(self):
-		return sp_api.CatalogItems(**self.instance_params)
 
-	def create_item_group(self, amazon_item):
-		item_group_name = amazon_item.get("AttributeSets")[0].get("ProductGroup")
+class AmazonCatalogItemsRepository(AmazonBaseRepository):
+	def __init__(self, amz_setting: str | AmazonSPAPISettings) -> None:
+		super().__init__(amz_setting)
 
-		if item_group_name:
-			item_group = frappe.db.get_value("Item Group", filters={"item_group_name": item_group_name})
-
-			if not item_group:
-				new_item_group = frappe.new_doc("Item Group")
-				new_item_group.item_group_name = item_group_name
-				new_item_group.parent_item_group = self.amz_setting.parent_item_group
-				new_item_group.insert()
-				return new_item_group.item_group_name
-
-			return item_group
-
-		raise (KeyError("ProductGroup"))
-
-	def create_brand(self, amazon_item):
-		brand_name = amazon_item.get("AttributeSets")[0].get("Brand")
-
-		if not brand_name:
-			return
-
-		existing_brand = frappe.db.get_value("Brand", filters={"brand": brand_name})
-
-		if not existing_brand:
-			brand = frappe.new_doc("Brand")
-			brand.brand = brand_name
-			brand.insert()
-			return brand.brand
-		else:
-			return existing_brand
-
-	def create_manufacturer(self, amazon_item):
-		manufacturer_name = amazon_item.get("AttributeSets")[0].get("Manufacturer")
-
-		if not manufacturer_name:
-			return
-
-		existing_manufacturer = frappe.db.get_value(
-			"Manufacturer", filters={"short_name": manufacturer_name}
-		)
-
-		if not existing_manufacturer:
-			manufacturer = frappe.new_doc("Manufacturer")
-			manufacturer.short_name = manufacturer_name
-			manufacturer.insert()
-			return manufacturer.short_name
-		else:
-			return existing_manufacturer
-
-	def create_ecommerce_item(self, item_code, asin, sku):
-		ecommerce_item = frappe.new_doc("Ecommerce Item")
-		ecommerce_item.integration = frappe.get_meta("Amazon SP API Settings").module
-		ecommerce_item.erpnext_item_code = item_code
-		ecommerce_item.integration_item_code = asin
-		ecommerce_item.sku = sku
-		ecommerce_item.insert(ignore_permissions=True)
-
-	def create_item_price(self, amazon_item, item_code):
-		item_price = frappe.new_doc("Item Price")
-		item_price.price_list = self.amz_setting.price_list
-		item_price.price_list_rate = (
-			amazon_item.get("AttributeSets")[0].get("ListPrice", {}).get("Amount") or 0
-		)
-		item_price.item_code = item_code
-		item_price.insert()
-
-	def create_item(self, amazon_item, asin, sku):
-		if frappe.db.get_value("Ecommerce Item", filters={"integration_item_code": asin}):
-			return asin
-
-		if frappe.db.exists("Item", asin):
-			item = frappe.get_doc("Item", asin)
-		else:
-			# Create Item
-			item = frappe.new_doc("Item")
-			item.item_code = asin
-			item.item_group = self.create_item_group(amazon_item)
-			item.description = amazon_item.get("AttributeSets")[0].get("Title")
-			item.brand = self.create_brand(amazon_item)
-			item.manufacturer = self.create_manufacturer(amazon_item)
-			item.image = amazon_item.get("AttributeSets")[0].get("SmallImage", {}).get("URL")
-			item.insert(ignore_permissions=True)
-
-			# Create Item Price
-			self.create_item_price(amazon_item, item.item_code)
-
-		# Create Ecommerce Item
-		self.create_ecommerce_item(item.item_code, asin, sku)
-
-		return item.item_code
-
-	def get_products_details(self):
-		products = []
-		report_id = self.create_report()
-
-		if report_id:
-			report_document = self.get_report_document(report_id)
-
-			if report_document:
-				catalog_items = self.get_catalog_items_instance()
-
-				for item in report_document:
-					asin = item.get("asin1") or item.get("product-id")
-					sku = item.get("seller-sku")
-					amazon_item = catalog_items.get_catalog_item(asin=asin).get("payload")
-					item_name = self.create_item(amazon_item, asin, sku)
-					products.append(item_name)
-
-		return products
-
-	# Related to Reports
-	def get_reports_instance(self):
-		return sp_api.Reports(**self.instance_params)
-
-	def create_report(
-		self, report_type="GET_FLAT_FILE_OPEN_LISTINGS_DATA", data_start_time=None, data_end_time=None
-	):
-		reports = self.get_reports_instance()
-		response = reports.create_report(
-			report_type=report_type, data_start_time=data_start_time, data_end_time=data_end_time,
-		)
-
-		return response.get("reportId")
-
-	def get_report_document(self, report_id):
-		reports = self.get_reports_instance()
-
-		for x in range(3):
-			response = reports.get_report(report_id)
-			processingStatus = response.get("processingStatus")
-
-			if not processingStatus:
-				raise (KeyError("processingStatus"))
-			elif processingStatus in ["IN_PROGRESS", "IN_QUEUE"]:
-				time.sleep(15)
-				continue
-			elif processingStatus in ["CANCELLED", "FATAL"]:
-				raise (f"Report Processing Status: {processingStatus}")
-			elif processingStatus == "DONE":
-				report_document_id = response.get("reportDocumentId")
-
-				if report_document_id:
-					response = reports.get_report_document(report_document_id)
-					url = response.get("url")
-
-					if url:
-						rows = []
-
-						for line in urllib.request.urlopen(url):
-							decoded_line = line.decode("utf-8").replace("\t", "\n")
-							row = decoded_line.splitlines()
-							rows.append(row)
-
-						fields = rows[0]
-						rows.pop(0)
-
-						data = []
-
-						for row in rows:
-							data_row = {}
-							for index, value in enumerate(row):
-								data_row[fields[index]] = value
-							data.append(data_row)
-
-						return data
-					raise (KeyError("url"))
-				raise (KeyError("reportDocumentId"))
+	def get_catalog_items_instance(self) -> CatalogItems:
+		return CatalogItems(**self.instance_params)
 
 
-# Helper functions
-def validate_amazon_sp_api_credentials(**args):
-	api = sp_api.SPAPI(
+def validate_amazon_sp_api_credentials(**args) -> None:
+	api = SPAPI(
 		iam_arn=args.get("iam_arn"),
 		client_id=args.get("client_id"),
 		client_secret=args.get("client_secret"),
@@ -554,16 +513,11 @@ def validate_amazon_sp_api_credentials(**args):
 		# validate aws_access_key, aws_secret_key, region and iam_arn.
 		api.get_auth()
 
-	except sp_api.SPAPIError as e:
+	except SPAPIError as e:
 		msg = f"<b>Error:</b> {e.error}<br/><b>Error Description:</b> {e.error_description}"
 		frappe.throw(msg)
 
 
-def get_orders(amz_setting_name, created_after):
-	amazon_repository = AmazonRepository(amz_setting_name)
-	return amazon_repository.get_orders(created_after)
-
-
-def get_products_details(amz_setting_name):
-	amazon_repository = AmazonRepository(amz_setting_name)
-	return amazon_repository.get_products_details()
+def get_orders(amz_setting_name, created_after) -> list:
+	aor = AmazonOrdersRepository(amz_setting_name)
+	return aor.get_orders(created_after)

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -202,7 +202,7 @@ class AmazonRepository:
 			make_address = frappe.new_doc("Address")
 			make_address.address_line1 = shipping_address.get("AddressLine1", "Not Provided")
 			make_address.city = shipping_address.get("City", "Not Provided")
-			make_address.state = shipping_address.get("StateOrRegion")
+			make_address.state = shipping_address.get("StateOrRegion").title()
 			make_address.pincode = shipping_address.get("PostalCode")
 
 			filters = [

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api.py
@@ -16,7 +16,6 @@ __all__ = [
 	"Finances",
 	"Orders",
 	"CatalogItems",
-	"Reports",
 ]
 
 
@@ -395,47 +394,6 @@ class CatalogItems(SPAPI):
 		data = dict(MarketplaceId=marketplace_id)
 
 		return self.make_request(append_to_base_uri=append_to_base_uri, params=data)
-
-
-class Reports(SPAPI):
-	""" Amazon Reports API """
-
-	BASE_URI = "/reports/2021-06-30"
-
-	def create_report(
-		self,
-		report_type: str,
-		report_options: dict = None,
-		data_start_time: str = None,
-		data_end_time: str = None,
-		marketplace_ids: list = None,
-	) -> dict:
-		""" Creates a report. """
-		append_to_base_uri = "/reports"
-		data = dict(
-			reportType=report_type,
-			reportOptions=report_options,
-			dataStartTime=data_start_time,
-			dataEndTime=data_end_time,
-		)
-
-		self.list_to_dict("marketplaceIds", marketplace_ids, data)
-
-		if not marketplace_ids:
-			marketplace_ids = [self.marketplace_id]
-			data["marketplaceIds"] = marketplace_ids
-
-		return self.make_request(method="POST", append_to_base_uri=append_to_base_uri, data=data)
-
-	def get_report(self, report_id: str) -> dict:
-		""" Returns report details (including the reportDocumentId, if available) for the report that you specify. """
-		append_to_base_uri = f"/reports/{report_id}"
-		return self.make_request(append_to_base_uri=append_to_base_uri)
-
-	def get_report_document(self, report_document_id: str) -> dict:
-		""" Returns the information required for retrieving a report document's contents. """
-		append_to_base_uri = f"/documents/{report_document_id}"
-		return self.make_request(append_to_base_uri=append_to_base_uri)
 
 
 class Util:

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
@@ -4,6 +4,8 @@
 frappe.ui.form.on('Amazon SP API Settings', {
 	refresh(frm) {
 		frm.trigger("set_queries");
+		frm.set_df_property("amazon_fields_map", "cannot_add_rows", true);
+		frm.set_df_property("amazon_fields_map", "cannot_delete_rows", true);
 	},
 
 	set_queries(frm) {

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.js
@@ -3,9 +3,22 @@
 
 frappe.ui.form.on('Amazon SP API Settings', {
 	refresh(frm) {
+		if (frm.doc.__islocal) {
+			frm.trigger("set_default_fields_map");
+		}
 		frm.trigger("set_queries");
 		frm.set_df_property("amazon_fields_map", "cannot_add_rows", true);
 		frm.set_df_property("amazon_fields_map", "cannot_delete_rows", true);
+	},
+
+	set_default_fields_map(frm) {
+		frappe.call({
+			method: "set_default_fields_map",
+			doc: frm.doc,
+			callback: (r) => {
+				if (!r.exc) refresh_field("amazon_fields_map");
+			},
+		});
 	},
 
 	set_queries(frm) {

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -203,6 +203,7 @@
    "label": "Sync Taxes and Charges"
   },
   {
+   "depends_on": "eval: !doc.__islocal && doc.is_active",
    "description": "Always sync your products from Amazon SP-API before synching the Orders details",
    "fieldname": "sync_products",
    "fieldtype": "Button",
@@ -210,6 +211,7 @@
    "options": "get_products_details"
   },
   {
+   "depends_on": "eval: !doc.__islocal && doc.is_active",
    "description": "Click this button to pull your Sales Order data from Amazon SP-API.",
    "fieldname": "sync_orders",
    "fieldtype": "Button",
@@ -263,7 +265,7 @@
   }
  ],
  "links": [],
- "modified": "2023-07-29 11:05:45.322565",
+ "modified": "2023-07-29 11:49:56.489018",
  "modified_by": "Administrator",
  "module": "Amazon",
  "name": "Amazon SP API Settings",

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -257,7 +257,7 @@
   }
  ],
  "links": [],
- "modified": "2023-07-31 13:37:26.735181",
+ "modified": "2023-07-31 17:20:21.492153",
  "modified_by": "Administrator",
  "module": "Amazon",
  "name": "Amazon SP API Settings",

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -33,7 +33,6 @@
   "section_break_3",
   "after_date",
   "taxes_charges",
-  "sync_products",
   "sync_orders",
   "column_break_4",
   "enable_sync",
@@ -189,7 +188,7 @@
    "label": "Syncing"
   },
   {
-   "description": "Amazon will synch data updated after this date",
+   "default": "Today",
    "fieldname": "after_date",
    "fieldtype": "Date",
    "label": "After Date",
@@ -201,14 +200,6 @@
    "fieldname": "taxes_charges",
    "fieldtype": "Check",
    "label": "Sync Taxes and Charges"
-  },
-  {
-   "depends_on": "eval: !doc.__islocal && doc.is_active",
-   "description": "Always sync your products from Amazon SP-API before synching the Orders details",
-   "fieldname": "sync_products",
-   "fieldtype": "Button",
-   "label": "Sync Products",
-   "options": "get_products_details"
   },
   {
    "depends_on": "eval: !doc.__islocal && doc.is_active",
@@ -224,6 +215,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: !doc.__islocal",
    "description": "Check this to enable a scheduled Daily synchronization routine via scheduler",
    "fieldname": "enable_sync",
    "fieldtype": "Check",
@@ -258,14 +250,14 @@
    "label": "Amazon Fields Map"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "create_item_if_not_exists",
    "fieldtype": "Check",
    "label": "Create Item If Not Exists"
   }
  ],
  "links": [],
- "modified": "2023-07-29 11:49:56.489018",
+ "modified": "2023-07-31 13:37:26.735181",
  "modified_by": "Administrator",
  "module": "Amazon",
  "name": "Amazon SP API Settings",

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2022-02-07 16:03:29.514729",
+ "creation": "2023-07-29 10:01:38.251734",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -27,6 +27,9 @@
   "territory",
   "customer_type",
   "market_place_account_group",
+  "amazon_fields_map_section",
+  "amazon_fields_map",
+  "create_item_if_not_exists",
   "section_break_3",
   "after_date",
   "taxes_charges",
@@ -48,8 +51,10 @@
    "label": "Is Active"
   },
   {
+   "collapsible": 1,
    "fieldname": "section_break_4",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Seller Central Credentials"
   },
   {
    "fieldname": "iam_arn",
@@ -84,8 +89,10 @@
    "reqd": 1
   },
   {
+   "collapsible": 1,
    "fieldname": "section_break_1",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "AWS Credentials"
   },
   {
    "fieldname": "aws_access_key",
@@ -113,7 +120,8 @@
   },
   {
    "fieldname": "section_break_2",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Setup"
   },
   {
    "fieldname": "company",
@@ -177,7 +185,8 @@
   },
   {
    "fieldname": "section_break_3",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Syncing"
   },
   {
    "description": "Amazon will synch data updated after this date",
@@ -234,10 +243,27 @@
    "print_hide": 1,
    "read_only": 1,
    "report_hide": 1
+  },
+  {
+   "fieldname": "amazon_fields_map",
+   "fieldtype": "Table",
+   "label": "Amazon - ERPNext Item Field Map",
+   "options": "Amazon Fields Map"
+  },
+  {
+   "fieldname": "amazon_fields_map_section",
+   "fieldtype": "Section Break",
+   "label": "Amazon Fields Map"
+  },
+  {
+   "default": "0",
+   "fieldname": "create_item_if_not_exists",
+   "fieldtype": "Check",
+   "label": "Create Item If Not Exists"
   }
  ],
  "links": [],
- "modified": "2022-04-19 17:08:28.354861",
+ "modified": "2023-07-29 11:05:45.322565",
  "modified_by": "Administrator",
  "module": "Amazon",
  "name": "Amazon SP API Settings",

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
@@ -12,6 +12,10 @@ from frappe.utils import add_days, today
 
 
 class AmazonSPAPISettings(Document):
+	def before_validate(self):
+		if not self.amazon_fields_map:
+			self.set_default_fields_map()
+
 	def validate(self):
 		self.validate_amazon_fields_map()
 		self.validate_after_date()
@@ -87,6 +91,15 @@ class AmazonSPAPISettings(Document):
 			aws_secret_key=self.get_password("aws_secret_key"),
 			country=self.get("country"),
 		)
+
+	@frappe.whitelist()
+	def set_default_fields_map(self):
+		for field_map in [
+			{"amazon_field": "ASIN", "item_field": "item_code", "use_to_find_item_code": 1},
+			{"amazon_field": "SellerSKU", "item_field": None, "use_to_find_item_code": 0,},
+			{"amazon_field": "Title", "item_field": None, "use_to_find_item_code": 0,},
+		]:
+			self.append("amazon_fields_map", field_map)
 
 	@frappe.whitelist()
 	def get_order_details(self):

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/test_amazon_sp_api_settings.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/test_amazon_sp_api_settings.py
@@ -22,7 +22,6 @@ from ecommerce_integrations.amazon.doctype.amazon_sp_api_settings.amazon_sp_api 
 	CatalogItems,
 	Finances,
 	Orders,
-	Reports,
 	SPAPIError,
 	Util,
 )
@@ -138,29 +137,6 @@ class TestCatalogItems(CatalogItems, TestSPAPI):
 		return super().get_catalog_item(asin, marketplace_id)
 
 
-class TestReports(Reports, TestSPAPI):
-	def create_report(
-		self,
-		report_type: str,
-		report_options: dict = None,
-		data_start_time: str = None,
-		data_end_time: str = None,
-		marketplace_ids: list = None,
-	) -> object:
-		self.expected_response = DATA.get("create_report_200")
-		return super().create_report(
-			report_type, report_options, data_start_time, data_end_time, marketplace_ids
-		)
-
-	def get_report(self, report_id: str) -> dict:
-		self.expected_response = DATA.get("get_report_200")
-		return super().get_report(report_id)
-
-	def get_report_document(self, report_document_id: str) -> dict:
-		self.expected_response = DATA.get("get_report_document_200")
-		return super().get_report_document(report_document_id)
-
-
 class TestAmazonSettings:
 	def __init__(self) -> None:
 		def get_company():
@@ -237,6 +213,10 @@ class TestAmazonSettings:
 		self.taxes_charges = 1
 		self.enable_sync = 1
 		self.max_retry_limit = 3
+		self.create_item_if_not_exists = 1
+		self.amazon_fields_map = [
+			frappe._dict({"amazon_field": "ASIN", "item_field": "item_code", "use_to_find_item_code": 1})
+		]
 
 
 class TestAmazonRepository(AmazonRepository):
@@ -272,31 +252,11 @@ class TestAmazonRepository(AmazonRepository):
 	def get_catalog_items_instance(self):
 		return TestCatalogItems(**self.instance_params)
 
-	def get_reports_instance(self):
-		return TestReports(**self.instance_params)
-
 
 class TestAmazon(unittest.TestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 		setup_custom_fields()
-		amazon_repository = TestAmazonRepository()
-		amazon_repository.get_products_details()
-
-	def test_get_products_details(self):
-		expected_result = {
-			"B008X9Z37A",
-			"B00H3LHY6C",
-			"B00AJHDZSI",
-			"B00DR0PDNE",
-			"B006QB1RPY",
-			"B001FWYGJS",
-			"B0041LYY6K",
-			"B001AZP8EW",
-		}
-		amazon_repository = TestAmazonRepository()
-		products = amazon_repository.get_products_details()
-		self.assertSetEqual(set(products), expected_result)
 
 	def test_get_orders(self):
 		amazon_repository = TestAmazonRepository()

--- a/ecommerce_integrations/patches.txt
+++ b/ecommerce_integrations/patches.txt
@@ -1,1 +1,2 @@
 ecommerce_integrations.patches.update_shopify_custom_fields
+ecommerce_integrations.patches.set_default_amazon_item_fields_map

--- a/ecommerce_integrations/patches/set_default_amazon_item_fields_map.py
+++ b/ecommerce_integrations/patches/set_default_amazon_item_fields_map.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def execute():
+	default_fields_map = [
+		{"amazon_field": "ASIN", "item_field": "item_code", "use_to_find_item_code": 1},
+		{"amazon_field": "SellerSKU", "item_field": None, "use_to_find_item_code": 0,},
+		{"amazon_field": "Title", "item_field": None, "use_to_find_item_code": 0,},
+	]
+	amz_settings = frappe.db.get_all("Amazon SP API Settings", pluck="name")
+
+	if amz_settings:
+		for amz_setting in amz_settings:
+			amz_setting_doc = frappe.get_doc("Amazon SP API Settings", amz_setting)
+
+			for field_map in default_fields_map:
+				amz_setting_doc.append("amazon_fields_map", field_map)
+
+			amz_setting_doc.save(ignore_version=True)


### PR DESCRIPTION
Issue: Both ASIN and SellerSKU are unique for every item/variant. Some users want to create/find the item based on SellerSKU.

Changes: 
- Added a table to map Amazon (ASIN, SellerSKU and Title) to ERPNext Items. [✅ Create Item If Not Exists]
- Allow the user to find the existing ERPNext Item with Amazon [ASIN/SellerSKU].
- New items will be created while creating a Sales Order based on `Create Item If Not Exists`.
- Sync Orders via RQ Job (4000). 
- Validation for `After Date` to be not more than 30 days old.
- Create customers based on marketplace email (if in the order payload).

![image](https://github.com/frappe/ecommerce_integrations/assets/63660334/477d78fa-2555-4af3-bcd6-38497e594547)

docs(draft): https://docs.erpnext.com/docs/user/manual/en/amazon_integration?editWiki=1&wikiPagePatch=3cbed74cc9
