### PR TITLE
fix(patch): `set_default_amazon_item_fields_map`

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
@@ -31,7 +31,9 @@ class AmazonSPAPISettings(Document):
 		elif self.max_retry_limit and self.max_retry_limit > 5:
 			frappe.throw(frappe._("Value for <b>Max Retry Limit</b> must be less than or equal to 5."))
 
-	def after_save(self):
+	def save(self):
+		super(AmazonSPAPISettings, self).save()
+
 		if not self.is_old_data_migrated:
 			migrate_old_data()
 			self.db_set("is_old_data_migrated", 1)

--- a/ecommerce_integrations/patches/set_default_amazon_item_fields_map.py
+++ b/ecommerce_integrations/patches/set_default_amazon_item_fields_map.py
@@ -2,6 +2,8 @@ import frappe
 
 
 def execute():
+	frappe.reload_doc("amazon", "doctype", "amazon_sp_api_settings")
+
 	default_fields_map = [
 		{"amazon_field": "ASIN", "item_field": "item_code", "use_to_find_item_code": 1},
 		{"amazon_field": "SellerSKU", "item_field": None, "use_to_find_item_code": 0,},
@@ -16,4 +18,5 @@ def execute():
 			for field_map in default_fields_map:
 				amz_setting_doc.append("amazon_fields_map", field_map)
 
+			amz_setting.flags.ignore_validate = True
 			amz_setting_doc.save(ignore_version=True)


### PR DESCRIPTION
- forgot to add `frappe.reload_doc` and ignore_validate (to ignore after date validation) in https://github.com/frappe/ecommerce_integrations/pull/260

