### PR TITLE
feat(shopify): Add Tax Template in Item table rows for Sales Order created from Shopify

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -282,7 +282,6 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 	"""Shipping lines represents the shipping details,
 	each such shipping detail consists of a list of tax_lines"""
 	shipping_as_item = cint(setting.add_shipping_as_item) and setting.shipping_item
-	shipping_charge_amount = 0
 	for shipping_charge in shipping_lines:
 		if shipping_charge.get("price"):
 			shipping_discounts = shipping_charge.get("discount_allocations") or []
@@ -298,7 +297,6 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 			item_tax_template = set_item_tax_template(setting.shipping_item, shipping_charge.get("tax_lines"), setting)
 
 			if shipping_as_item:
-				if shipping_charge_amount != 0:
 					items.append(
 						{
 							"item_code": setting.shipping_item,
@@ -322,7 +320,6 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 				)
 
 		for tax in shipping_charge.get("tax_lines"):
-			if shipping_charge_amount != 0:
 				taxes.append(
 					{
 						"charge_type": "Actual",

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -298,7 +298,7 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 			item_tax_template = set_item_tax_template(setting.shipping_item, shipping_charge.get("tax_lines"), setting)
 
 			if shipping_as_item:
-				if shipping_charge_amount > 0:
+				if shipping_charge_amount != 0:
 					items.append(
 						{
 							"item_code": setting.shipping_item,
@@ -322,7 +322,7 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 				)
 
 		for tax in shipping_charge.get("tax_lines"):
-			if shipping_charge_amount > 0:
+			if shipping_charge_amount != 0:
 				taxes.append(
 					{
 						"charge_type": "Actual",


### PR DESCRIPTION
PR is raised against frappe support ticket - https://support.frappe.io/helpdesk/my-tickets/1512

This PR is to add the item tax template as per the tax specified in shopify order items to each row of item table in ERPNext.

This will resolve following issues-

- After cancellation of sales order while amending orders tax is not calculated correctly.

- If shipping charge is zero row is appending for shipping charge in the item table.

- cost center is not updating at doc-level field.