### PR TITLE
feat: specify default tax accounts

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/shopify_setting.json
@@ -23,8 +23,6 @@
   "cash_bank_account",
   "column_break_19",
   "cost_center",
-  "inventory_settings_section",
-  "column_break_22",
   "section_break_25",
   "sales_order_series",
   "delivery_note_series",
@@ -38,6 +36,10 @@
   "section_break_22",
   "html_16",
   "taxes",
+  "section_break_zeoy",
+  "default_sales_tax_account",
+  "column_break_qibo",
+  "default_shipping_charges_account",
   "erpnext_to_shopify_sync_section",
   "upload_erpnext_items",
   "update_shopify_item_on_update",
@@ -123,11 +125,6 @@
    "label": "Customer Group",
    "mandatory_depends_on": "eval:doc.enable_shopify",
    "options": "Customer Group"
-  },
-  {
-   "fieldname": "inventory_settings_section",
-   "fieldtype": "Section Break",
-   "label": "Inventory Settings"
   },
   {
    "description": "If individual warehouse are not mapped, the default warehouse is considered for transactions.",
@@ -234,10 +231,6 @@
    "label": "Shopify Tax Account",
    "mandatory_depends_on": "eval:doc.enable_shopify",
    "options": "Shopify Tax Account"
-  },
-  {
-   "fieldname": "column_break_22",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "erpnext_to_shopify_sync_section",
@@ -371,12 +364,35 @@
    "fieldname": "consolidate_taxes",
    "fieldtype": "Check",
    "label": "Consolidate Taxes in Order"
+  },
+  {
+   "description": "When no sales tax mapping is found this tax account will be used as the default account. This is only applied for Sales Tax. Any shipping related charges still need to be mapped separately.",
+   "fieldname": "default_sales_tax_account",
+   "fieldtype": "Link",
+   "label": "Default Sales Tax Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "section_break_zeoy",
+   "fieldtype": "Section Break",
+   "hide_border": 1
+  },
+  {
+   "fieldname": "column_break_qibo",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "When no shipping charge account mapping is found this account will be used as the default account.",
+   "fieldname": "default_shipping_charges_account",
+   "fieldtype": "Link",
+   "label": "Default Shipping Charges Account",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-02-10 10:36:12.940019",
+ "modified": "2023-10-24 10:38:49.247431",
  "modified_by": "Administrator",
  "module": "shopify",
  "name": "Shopify Setting",

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -399,26 +399,17 @@ def sync_old_orders():
 	if not cint(shopify_setting.sync_old_orders):
 		return
 
-	try:
-		orders = _fetch_old_orders(shopify_setting.old_orders_from, shopify_setting.old_orders_to)
+	orders = _fetch_old_orders(shopify_setting.old_orders_from, shopify_setting.old_orders_to)
 
-		for order in orders:
-			log = create_shopify_log(
-				method=EVENT_MAPPER["orders/create"], request_data=json.dumps(order), make_new=True
-			)
-			sync_sales_order(order, request_id=log.name)
-
-		shopify_setting = frappe.get_doc(SETTING_DOCTYPE)
-		shopify_setting.sync_old_orders = 0
-		shopify_setting.save()
-
-		create_shopify_log(
-			status="Success", method="ecommerce_integrations.shopify.order.sync_old_orders"
+	for order in orders:
+		log = create_shopify_log(
+			method=EVENT_MAPPER["orders/create"], request_data=json.dumps(order), make_new=True
 		)
-	except Exception as e:
-		create_shopify_log(
-			status="Error", method="ecommerce_integrations.shopify.order.sync_old_orders", exception=e
-		)
+		sync_sales_order(order, request_id=log.name)
+
+	shopify_setting = frappe.get_doc(SETTING_DOCTYPE)
+	shopify_setting.sync_old_orders = 0
+	shopify_setting.save()
 
 
 def _fetch_old_orders(from_time, to_time):

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -1,4 +1,5 @@
 import json
+from typing import Literal, Optional
 
 import frappe
 from frappe import _
@@ -21,6 +22,11 @@ from ecommerce_integrations.shopify.product import create_items_if_not_exist, ge
 from ecommerce_integrations.shopify.utils import create_shopify_log
 from ecommerce_integrations.utils.price_list import get_dummy_price_list
 from ecommerce_integrations.utils.taxation import get_dummy_tax_category
+
+DEFAULT_TAX_FIELDS = {
+	"sales_tax": "default_sales_tax_account",
+	"shipping": "default_shipping_charges_account",
+}
 
 
 def sync_sales_order(payload, request_id=None):
@@ -197,7 +203,7 @@ def get_order_taxes(shopify_order, setting, items):
 			taxes.append(
 				{
 					"charge_type": "Actual",
-					"account_head": get_tax_account_head(tax),
+					"account_head": get_tax_account_head(tax, charge_type="sales_tax"),
 					"description": (
 						get_tax_account_description(tax) or f"{tax.get('title')} - {tax.get('rate') * 100.0:.2f}%"
 					),
@@ -252,12 +258,15 @@ def consolidate_order_taxes(taxes):
 	return tax_account_wise_data.values()
 
 
-def get_tax_account_head(tax):
+def get_tax_account_head(tax, charge_type: Optional[Literal["shipping", "sales_tax"]] = None):
 	tax_title = str(tax.get("title"))
 
 	tax_account = frappe.db.get_value(
 		"Shopify Tax Account", {"parent": SETTING_DOCTYPE, "shopify_tax": tax_title}, "tax_account",
 	)
+
+	if not tax_account and charge_type:
+		tax_account = frappe.db.get_single_value(SETTING_DOCTYPE, DEFAULT_TAX_FIELDS[charge_type])
 
 	if not tax_account:
 		frappe.throw(_("Tax Account not specified for Shopify Tax {0}").format(tax.get("title")))
@@ -306,7 +315,7 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 				taxes.append(
 					{
 						"charge_type": "Actual",
-						"account_head": get_tax_account_head(shipping_charge),
+						"account_head": get_tax_account_head(shipping_charge, charge_type="shipping"),
 						"description": get_tax_account_description(shipping_charge) or shipping_charge["title"],
 						"tax_amount": shipping_charge_amount,
 						"cost_center": setting.cost_center,
@@ -317,7 +326,7 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 			taxes.append(
 				{
 					"charge_type": "Actual",
-					"account_head": get_tax_account_head(tax),
+					"account_head": get_tax_account_head(tax, charge_type="sales_tax"),
 					"description": (
 						get_tax_account_description(tax) or f"{tax.get('title')} - {tax.get('rate') * 100.0:.2f}%"
 					),


### PR DESCRIPTION
In countries with USA which has complex taxation for each state, counties etc. it's next to impossible to map all possible tax titles to an account.

This PR adds a fallback account for all sales tax to handle those cases.

Similarly a fallback shipping charge account is introduced.

Note: It's recommended to only use this as last resort, otherwise you might end up posting all entries in single account whereas your accountants might expect you to post in diff accounts. e.g. in India there are only 4-5 legitimate tax account requirements, so it's better not to use default accounts and stick with mapping individual ones.

closes https://github.com/frappe/ecommerce_integrations/issues/194

Internal reference: https://support.frappe.io/helpdesk/tickets/4848
