### PR TITLE
fix: throw if shopify isn't configured yet session is required

### DIFF
--- a/ecommerce_integrations/shopify/connection.py
+++ b/ecommerce_integrations/shopify/connection.py
@@ -35,6 +35,12 @@ def temp_shopify_session(func):
 
 			with Session.temp(*auth_details):
 				return func(*args, **kwargs)
+		frappe.throw(
+			_(
+				"This action requires to establish a shopify settion. Please configure your"
+				" credentials in the Shopify Setting."
+			)
+		)
 
 	return wrapper
 


### PR DESCRIPTION
Avoid spurious user facing errors.
