### PR TITLE
fix(shopify): handle multiple instance of same item in delivery

### DIFF
--- a/ecommerce_integrations/shopify/fulfillment.py
+++ b/ecommerce_integrations/shopify/fulfillment.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import frappe
 from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
 from frappe.utils import cint, cstr, getdate
@@ -62,13 +64,26 @@ def get_fulfillment_items(dn_items, fulfillment_items, location_id=None):
 	# local import to avoid circular imports
 	from ecommerce_integrations.shopify.product import get_item_code
 
+	fulfillment_items = deepcopy(fulfillment_items)
+
 	setting = frappe.get_cached_doc(SETTING_DOCTYPE)
 	wh_map = setting.get_integration_to_erpnext_wh_mapping()
 	warehouse = wh_map.get(str(location_id)) or setting.warehouse
 
-	return [
-		dn_item.update({"qty": item.get("quantity"), "warehouse": warehouse})
-		for item in fulfillment_items
-		for dn_item in dn_items
-		if get_item_code(item) == dn_item.item_code
-	]
+	final_items = []
+
+	def find_matching_fullfilement_item(dn_item):
+		nonlocal fulfillment_items
+
+		for item in fulfillment_items:
+			if get_item_code(item) == dn_item.item_code:
+				fulfillment_items.remove(item)
+				return item
+
+	for dn_item in dn_items:
+		if shopify_item := find_matching_fullfilement_item(dn_item):
+			final_items.append(
+				dn_item.update({"qty": shopify_item.get("quantity"), "warehouse": warehouse})
+			)
+
+	return final_items


### PR DESCRIPTION
Earlier the code assumed item can only be used once in order. This
change now uses fifo type assignment of shopify line items to delivery
note line items to only map item code once and then pop it.
