### PR TITLE
fix: shopify sync issue without customer

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -75,8 +75,9 @@ def create_order(order, setting, company=None):
 
 def create_sales_order(shopify_order, setting, company=None):
 	customer = setting.default_customer
-	if customer_id := shopify_order.get("customer", {}).get("id"):
-		customer = frappe.db.get_value("Customer", {CUSTOMER_ID_FIELD: customer_id}, "name")
+	if shopify_order.get("customer", {}):
+		if customer_id := shopify_order.get("customer", {}).get("id"):
+			customer = frappe.db.get_value("Customer", {CUSTOMER_ID_FIELD: customer_id}, "name")
 
 	so = frappe.db.get_value("Sales Order", {ORDER_ID_FIELD: shopify_order.get("id")}, "name")
 


### PR DESCRIPTION
Without customer getting the below error while syncing sales orders from Shopify to ERPNext

```
Traceback (most recent call last):
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 55, in sync_sales_order
    create_order(order, setting)
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 67, in create_order
    so = create_sales_order(order, setting, company)
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/order.py", line 78, in create_sales_order
    if customer_id := shopify_order.get("customer", {}).get("id"):
AttributeError: 'NoneType' object has no attribute 'get'
```