### PR TITLE
feat: add linking method to ecommece customer controller

### DIFF
--- a/ecommerce_integrations/controllers/customer.py
+++ b/ecommerce_integrations/controllers/customer.py
@@ -16,6 +16,10 @@ class EcommerceCustomer:
 
 		return bool(frappe.db.exists("Customer", {self.customer_id_field: self.customer_id}))
 
+	def link(self, customer) -> None:
+		customer.set_value(self.customer_id_field, self.customer_id)
+		customer.db_set(self.customer_id_field, self.customer_id, commit=True)
+
 	def get_customer_doc(self):
 		"""Get ERPNext customer document."""
 		if self.is_synced():


### PR DESCRIPTION
# Context

The Primary address and contact of a customer are customarily used to aquire defaults across ERPNext.

They furtheromre serve as a fallback customer identification scheme, for example based on email or phone number of their primary contact.

However, the ecommerce controller did not properly set those fields upon creating a new customer

# Proposed Solution

- [x] Ensure the `primary_*` fields are set for the Shopify Integration (since only the Shopify Integration uses the controller)
