### PR TITLE
fix: make integration read-only

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
@@ -28,7 +28,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Integration",
-   "options": "Module Def"
+   "options": "Module Def",
+   "read_only": 1
   },
   {
    "default": "Queued",


### PR DESCRIPTION
Too risky to leave this open to user manipulation by default
