### PR TITLE
feat: manual ecommerce item linker widget

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_item/ecommerce_item.py
@@ -83,6 +83,26 @@ def _is_sku_synced(integration: str, sku: str) -> bool:
 	return bool(frappe.db.exists("Ecommerce Item", filter))
 
 
+def switch_to_product_id(
+	integration: str,
+	integration_item_code: str,
+	sku: str,
+	variant_id: Optional[str] = None,
+	has_variants: Optional[int] = 0,
+):
+	filters = {"integration": integration, "sku": sku}
+	ecommerce_item = frappe.get_last_doc("Ecommerce Item", filters)
+	ecommerce_item.update(
+		{
+			"sku": None,
+			"integration_item_code": integration_item_code,
+			"variant_id": variant_id,
+			"has_variants": has_variants,
+		}
+	)
+	ecommerce_item.db_update()
+
+
 def get_erpnext_item_code(
 	integration: str,
 	integration_item_code: str,

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -41,7 +41,7 @@ doctype_js = {
 		"public/js/unicommerce/sales_invoice.js",
 		"public/js/common/ecommerce_transactions.js",
 	],
-	"Item": "public/js/unicommerce/item.js",
+	"Item": ["public/js/common/ecommerce_item.js", "public/js/unicommerce/item.js",],
 	"Stock Entry": "public/js/unicommerce/stock_entry.js",
 	"Pick List": "public/js/unicommerce/pick_list.js",
 }

--- a/ecommerce_integrations/public/js/common/ecommerce_item.js
+++ b/ecommerce_integrations/public/js/common/ecommerce_item.js
@@ -1,0 +1,57 @@
+frappe.provide("frappe.ui.form");
+
+frappe.ui.form.EcommerceItemQuickEntryForm = class EcommerceItemQuickEntryForm extends (
+	frappe.ui.form.QuickEntryForm
+) {
+	render_dialog() {
+		this.mandatory = this.mandatory.concat(this.get_variant_fields());
+		super.render_dialog();
+	}
+	insert() {
+		/**
+		 * Using alias fieldnames because the doctype definition define them as readonly fields.
+		 * Therefor, resulting in the fields being "hidden".
+		 */
+		const map_field_names = {
+			d_integration: "integration",
+			d_erpnext_item_code: "erpnext_item_code",
+			d_sku: "sku",
+		};
+
+		Object.entries(map_field_names).forEach(([fieldname, new_fieldname]) => {
+			this.dialog.doc[new_fieldname] = this.dialog.doc[fieldname];
+			delete this.dialog.doc[fieldname];
+		});
+
+		return super.insert();
+	}
+	get_variant_fields() {
+		var variant_fields = [
+			{
+				label: __("Integration"),
+				fieldname: "d_integration",
+				fieldtype: "Link",
+				options: "Module Def",
+				reqd: 1.
+			},
+			{
+				label: __("ERPNext Item Code"),
+				fieldname: "d_erpnext_item_code",
+				fieldtype: "Link",
+				options: "Item",
+				reqd: 1.
+			},
+			{
+				fieldtype: "Column Break",
+			},
+			{
+				fieldtype: "Data",
+				label: __("SKU"),
+				fieldname: "d_sku",
+				reqd: 1.
+			},
+		];
+
+		return variant_fields;
+	}
+};


### PR DESCRIPTION
# Context

- Ecommerce without possibility to sync
- Integrations without desire to sync in order to incentivize the primacy of the ERP master data as the source of truth

# Solution
- Add a manual mapper to record link items which exists in Ecommerce but not in ERP
- Add a switch to change a "loose" SKU mapping to a "strong" ID mapping; useful in the second use case above
