### PR TITLE
feat/integration log references

### DIFF
--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
@@ -8,8 +8,13 @@
   "title",
   "integration",
   "status",
-  "method",
+  "column_break_fhrq",
+  "psl",
+  "payment_status",
+  "is_retry",
+  "section_break_swkt",
   "message",
+  "method",
   "traceback",
   "request_data",
   "response_data"
@@ -66,11 +71,42 @@
    "fieldtype": "Code",
    "label": "Response Data",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Use to exclude reties from notifications",
+   "fieldname": "is_retry",
+   "fieldtype": "Check",
+   "label": "Is Retry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payment_status",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Payment Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "psl",
+   "fieldtype": "Link",
+   "label": "Payment Session Log",
+   "options": "Payment Session Log",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_fhrq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_swkt",
+   "fieldtype": "Section Break"
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-05-28 16:06:49.008875",
+ "modified": "2024-06-19 07:07:27.547511",
  "modified_by": "Administrator",
  "module": "Ecommerce Integrations",
  "name": "Ecommerce Integration Log",

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.json
@@ -12,6 +12,8 @@
   "psl",
   "payment_status",
   "is_retry",
+  "reference_doctype",
+  "reference_docname",
   "section_break_swkt",
   "message",
   "method",
@@ -102,11 +104,24 @@
   {
    "fieldname": "section_break_swkt",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference Doctype",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_docname",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Docname",
+   "options": "reference_doctype"
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-06-19 07:07:27.547511",
+ "modified": "2024-06-23 13:51:52.650162",
  "modified_by": "Administrator",
  "module": "Ecommerce Integrations",
  "name": "Ecommerce Integration Log",

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -48,6 +48,8 @@ def create_log(
 	message=None,
 	make_new=False,
 	payment_status=None,
+	reference_doctype=None,
+	reference_docname=None,
 ):
 	make_new = make_new or not bool(frappe.flags.request_id)
 
@@ -68,6 +70,10 @@ def create_log(
 
 	if payment_status:
 		log.payment_status = payment_status
+	if reference_doctype:
+		log.reference_doctype = reference_doctype
+	if reference_docname:
+		log.reference_docname = reference_docname
 
 	log.message = message or _get_message(exception)
 	log.method = log.method or method

--- a/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
+++ b/ecommerce_integrations/ecommerce_integrations/doctype/ecommerce_integration_log/ecommerce_integration_log.py
@@ -47,6 +47,7 @@ def create_log(
 	method=None,
 	message=None,
 	make_new=False,
+	payment_status=None,
 ):
 	make_new = make_new or not bool(frappe.flags.request_id)
 
@@ -64,6 +65,9 @@ def create_log(
 
 	if request_data and not isinstance(request_data, str):
 		request_data = json.dumps(request_data, sort_keys=True, indent=4)
+
+	if payment_status:
+		log.payment_status = payment_status
 
 	log.message = message or _get_message(exception)
 	log.method = log.method or method

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -9,6 +9,8 @@ app_color = "grey"
 app_email = "developers@frappe.io"
 app_license = "GNU GPL v3.0"
 
+required_apps = ["payments", "erpnext"]
+
 # Includes in <head>
 # ------------------
 

--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -168,6 +168,10 @@ scheduler_events = {
 # bootinfo - hide old doctypes
 extend_bootinfo = "ecommerce_integrations.boot.boot_session"
 
+ignore_links_on_delete = [
+	"Ecommerce Integration Log",
+]
+
 # Testing
 # -------
 


### PR DESCRIPTION
- feat: link ecommerce integration log with payment session log
- feat: add reference doc to ecommerce integration log

# Context

- Frappe may act as "custom payment method"
- The special checkout page captures the order data
- Then it either or issues (background) synchronization
- It then redirects to the payment session
- The EIL becomes the central integration document for in-flight orders
  - Therefore the payment status and PSL is replicated onto it to quickly assess the overall status of such checkout
- The payment session runs a success hook on its refdoc (= the EIL)
  - Therefore hold a reference to the refdoc of the EIL
  - This allows charge success hooks to affect the business flow of the actual target refdoc (i.e. Sales Order), assuming that the synchronization had been successful and that it had written back the reference of the target doc onto the EIL


This is used by a WIP Ecwid integration, but which is not yet quite ready to PR.
