### PR TITLE
Amazon FBA auto removal orders break sync

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -401,7 +401,17 @@ class AmazonRepository:
 			customer_name = create_customer(order)
 			create_address(order, customer_name)
 
-			delivery_date = dateutil.parser.parse(order.get("LatestShipDate")).strftime("%Y-%m-%d")
+			def add_year_to_iso_string(ship_date_iso,purchase_date_iso):
+			    year = int(ship_date_iso[:4])
+			    if year < 2000:
+					year = int(purchase_date_iso[:4])
+			        new_year = str(year + 1)
+			        return new_year + purchase_date_iso[4:]
+			    return ship_date_iso
+
+			
+
+			delivery_date = dateutil.parser.parse(add_year_to_iso_string(order.get("LatestShipDate"),order.get("PurchaseDate"))).strftime("%Y-%m-%d")
 			transaction_date = dateutil.parser.parse(order.get("PurchaseDate")).strftime("%Y-%m-%d")
 
 			so = frappe.new_doc("Sales Order")


### PR DESCRIPTION
It appears when the FBA auto removal order is scheduled, the ship date given by Amazon is 1995. which causes a validation error which then breaks the sync and prevents it from syncing further. for the time being I've added a check to automatically mark these orders with year + 1 as of buy date so it doesn't fail the sync.