### PR TITLE
refactor: update Shopify migration flow to remove dependency on custom fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 


### PR DESCRIPTION
Issue:
Shopify migration is stuck with status Queued when using migrate_from_old_connector. The process does not complete.

Fix:
Update Shopify migration flow to remove dependency on custom fields.