### PR TITLE
fix: Sales Order currency will follow Shopify order currency

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -109,6 +109,7 @@ def create_sales_order(shopify_order, setting, company=None):
 				ORDER_ID_FIELD: str(shopify_order.get("id")),
 				ORDER_NUMBER_FIELD: shopify_order.get("name"),
 				"customer": customer,
+				"currency": shopify_order.get("currency"),
 				"transaction_date": getdate(shopify_order.get("created_at")) or nowdate(),
 				"delivery_date": getdate(shopify_order.get("created_at")) or nowdate(),
 				"company": setting.company,


### PR DESCRIPTION
In case the Company's default currency is not the same as the currency from Shopify. The `currency` field needs to be explicitly specified here.