### PR TITLE
fix(shopify): set hsn code on item if present

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -18,7 +18,7 @@ from ecommerce_integrations.shopify.constants import (
 	SETTING_DOCTYPE,
 )
 from ecommerce_integrations.shopify.customer import ShopifyCustomer
-from ecommerce_integrations.shopify.product import create_items_if_not_exist, get_item_code
+from ecommerce_integrations.shopify.product import create_items_if_not_exist, get_item_code, set_hsn_code
 from ecommerce_integrations.shopify.utils import create_shopify_log
 from ecommerce_integrations.utils.price_list import get_dummy_price_list
 from ecommerce_integrations.utils.taxation import get_dummy_tax_category
@@ -151,20 +151,19 @@ def get_order_items(order_items, setting, delivery_date, taxes_inclusive):
 
 		if all_product_exists:
 			item_code = get_item_code(shopify_item)
-			items.append(
-				{
-					"item_code": item_code,
-					"item_name": shopify_item.get("name"),
-					"rate": _get_item_price(shopify_item, taxes_inclusive),
-					"delivery_date": delivery_date,
-					"qty": shopify_item.get("quantity"),
-					"stock_uom": shopify_item.get("uom") or "Nos",
-					"warehouse": setting.warehouse,
-					ORDER_ITEM_DISCOUNT_FIELD: (
-						_get_total_discount(shopify_item) / cint(shopify_item.get("quantity"))
-					),
-				}
+			item = frappe._dict()
+			item.item_code = item_code
+			item.item_name = shopify_item.get("name")
+			item.rate = _get_item_price(shopify_item, taxes_inclusive)
+			item.delivery_date = delivery_date
+			item.qty = shopify_item.get("quantity")
+			item.stock_uom = shopify_item.get("uom") or "Nos"
+			item.warehouse = setting.warehouse
+			item[ORDER_ITEM_DISCOUNT_FIELD] = (
+				_get_total_discount(shopify_item) / cint(shopify_item.get("quantity"))
 			)
+			set_hsn_code(item)
+			items.append(item)
 		else:
 			items = []
 

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -327,6 +327,12 @@ def get_item_code(shopify_item):
 	if item:
 		return item.item_code
 
+def set_hsn_code(item: dict):
+	if "india_compliance" in frappe.get_installed_apps():
+		hsn_code, item_group = frappe.db.get_value("Item", item.item_code, ("gst_hsn_code", "item_group"))
+		if not hsn_code:
+			hsn_code = frappe.db.get_value("Item Group", item_group, "gst_hsn_code")
+		item.gst_hsn_code = hsn_code
 
 @temp_shopify_session
 def upload_erpnext_item(doc, method=None):


### PR DESCRIPTION
Issue: HSN code is not being set on order items during order sync,

Ref: [#42622](https://support.frappe.io/helpdesk/tickets/42622)

Before:

https://github.com/user-attachments/assets/52c879a5-ba48-48d3-b9a9-edbb55fffaf1

After:

https://github.com/user-attachments/assets/78584033-dcc8-4554-a63f-d62a4721fbda
