### PR TITLE
fix: Add required_apps hooks for erpnext

### DIFF
--- a/ecommerce_integrations/hooks.py
+++ b/ecommerce_integrations/hooks.py
@@ -8,6 +8,7 @@ app_icon = "octicon octicon-file-directory"
 app_color = "grey"
 app_email = "developers@frappe.io"
 app_license = "GNU GPL v3.0"
+required_apps = ["frappe/erpnext"]
 
 # Includes in <head>
 # ------------------


### PR DESCRIPTION
fixes https://github.com/frappe/ecommerce_integrations/issues/369

<img width="2088" height="996" alt="image" src="https://github.com/user-attachments/assets/04d4f52b-a6aa-4f73-ba60-40d732afe1d4" />
