### PR TITLE
fix(amazon): replace deprecated API with working endpoint

### DIFF
--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -156,7 +156,7 @@ class AmazonRepository:
 
 	def create_item(self, order_item) -> str:
 		def create_item_group(amazon_item) -> str:
-			item_group_name = amazon_item.get("AttributeSets")[0].get("ProductGroup")
+			item_group_name = amazon_item.get("productTypes", [{}])[0].get("productType")
 
 			if item_group_name:
 				item_group = frappe.db.get_value("Item Group", filters={"item_group_name": item_group_name})
@@ -172,7 +172,7 @@ class AmazonRepository:
 			raise (KeyError("ProductGroup"))
 
 		def create_brand(amazon_item) -> str:
-			brand_name = amazon_item.get("AttributeSets")[0].get("Brand")
+			brand_name = amazon_item.get("attributes", {}).get("brand", [{}])[0].get("value")
 
 			if not brand_name:
 				return
@@ -187,7 +187,7 @@ class AmazonRepository:
 			return existing_brand
 
 		def create_manufacturer(amazon_item) -> str:
-			manufacturer_name = amazon_item.get("AttributeSets")[0].get("Manufacturer")
+			manufacturer_name = amazon_item.get("attributes", {}).get("manufacturer", [{}])[0].get("value")
 
 			if not manufacturer_name:
 				return
@@ -207,7 +207,7 @@ class AmazonRepository:
 			item_price = frappe.new_doc("Item Price")
 			item_price.price_list = self.amz_setting.price_list
 			item_price.price_list_rate = (
-				amazon_item.get("AttributeSets")[0].get("ListPrice", {}).get("Amount") or 0
+				amazon_item.get("attributes", {}).get("list_price", [{}])[0].get("value", 0) or 0
 			)
 			item_price.item_code = item_code
 			item_price.insert()
@@ -221,7 +221,7 @@ class AmazonRepository:
 			ecommerce_item.insert(ignore_permissions=True)
 
 		catalog_items = self.get_catalog_items_instance()
-		amazon_item = catalog_items.get_catalog_item(order_item["ASIN"])["payload"]
+		amazon_item = catalog_items.get_catalog_item(order_item["ASIN"])
 
 		item = frappe.new_doc("Item")
 

--- a/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api.py
+++ b/ecommerce_integrations/amazon/doctype/amazon_sp_api_settings/amazon_sp_api.py
@@ -383,7 +383,7 @@ class Orders(SPAPI):
 class CatalogItems(SPAPI):
 	"""Amazon Catalog Items API"""
 
-	BASE_URI = "/catalog/v0"
+	BASE_URI = "/catalog/2022-04-01"
 
 	def get_catalog_item(
 		self,
@@ -395,7 +395,10 @@ class CatalogItems(SPAPI):
 			marketplace_id = self.marketplace_id
 
 		append_to_base_uri = f"/items/{asin}"
-		data = dict(MarketplaceId=marketplace_id)
+		data = dict(
+			marketplaceIds=[marketplace_id],
+			includedData="attributes,productTypes"
+		)
 
 		return self.make_request(append_to_base_uri=append_to_base_uri, params=data)
 


### PR DESCRIPTION
**Summary:**
The previous API used for fetching product details was deprecated, resulting in failed requests.  
This commit updates the integration to use the new, active API endpoint provided by Amazon.

**Changes:**
- Updated endpoint path and parameters.
- Adjusted response parsing to match new API response format.

**Testing:**
- Successfully retrieved product details for multiple ASINs.
- Verified response structure and field mapping.

Closes #355 #307 
