### PR TITLE
fix: validate customer before creating sales order

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -38,7 +38,10 @@ def sync_sales_order(payload, request_id=None):
 		create_shopify_log(status="Invalid", message="Sales order already exists, not synced")
 		return
 	try:
-		shopify_customer = order.get("customer") if order.get("customer") is not None else {}
+		shopify_customer = order.get("customer")
+		if shopify_customer is None:
+			create_shopify_log(status="Error", message="Invalid Order:customer is null")
+			return
 		shopify_customer["billing_address"] = order.get("billing_address", "")
 		shopify_customer["shipping_address"] = order.get("shipping_address", "")
 		customer_id = shopify_customer.get("id")


### PR DESCRIPTION
**Issue**: Sales order created without the customer for Shopify orders.

**Before:**
<img width="1634" height="717" alt="image" src="https://github.com/user-attachments/assets/ca4fe581-b85f-47ff-aa9c-e1f3562618e6" />

<img width="1627" height="770" alt="image" src="https://github.com/user-attachments/assets/93d979c6-38a5-4aef-937b-53748c9f6749" />



**After:** 
<img width="1637" height="831" alt="image" src="https://github.com/user-attachments/assets/4f499ff9-3528-4694-a199-cf6f37fe883e" />




