### PR TITLE
fix: bump shopifyapi to 12.7.0 for python 3.13+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "./README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "ShopifyAPI==12.4.0",  # update after resolving pyjwt conflict in frappe
+    "ShopifyAPI==12.7.0",
     "boto3~=1.34.143",
 ]
 


### PR DESCRIPTION
Issue:  shopify product sync fails on python 3.13+ because ShopifyAPI 12.4.0 imports the removed cgi module. update ShopifyAPI to 12.7.0 to restore compatibility

Ref: [#67340](https://support.frappe.io/helpdesk/tickets/67340)

Traceback: 

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 120, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 52, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1760, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/save.py", line 39, in savedocs
    doc.save()
    ~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 431, in _save
    self.run_post_save_methods()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 1180, in run_post_save_methods
    self.run_method("on_update")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1014, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1371, in composer
    hooks.append(frappe.get_attr(handler))
                 ~~~~~~~~~~~~~~~^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1750, in get_attr
    return getattr(get_module(modulename), methodname)
                   ~~~~~~~~~~^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1460, in get_module
    return importlib.import_module(modulename)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1406, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 759, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "apps/ecommerce_integrations/ecommerce_integrations/shopify/product.py", line 1, in <module>
    from shopify.resources import Product, Variant
  File "env/lib/python3.14/site-packages/shopify/__init__.py", line 3, in <module>
    from shopify.resources import *
  File "env/lib/python3.14/site-packages/shopify/resources/__init__.py", line 1, in <module>
    from .shop import Shop
  File "env/lib/python3.14/site-packages/shopify/resources/shop.py", line 1, in <module>
    from ..base import ShopifyResource
  File "env/lib/python3.14/site-packages/shopify/base.py", line 11, in <module>
    from shopify.collection import PaginatedCollection
  File "env/lib/python3.14/site-packages/shopify/collection.py", line 3, in <module>
    import cgi
ModuleNotFoundError: No module named 'cgi'
```