### PR TITLE
fix: use shopify customer id as fallback

### DIFF
--- a/ecommerce_integrations/shopify/customer.py
+++ b/ecommerce_integrations/shopify/customer.py
@@ -25,6 +25,9 @@ class ShopifyCustomer(EcommerceCustomer):
 		if len(customer_name.strip()) == 0:
 			customer_name = customer.get("email")
 
+		if not customer_name:
+			customer_name = cstr(customer.get("id"))
+
 		customer_group = self.setting.customer_group
 		super().sync_customer(customer_name, customer_group)
 


### PR DESCRIPTION
Issue: 
when syncing shopify orders, customer creation fails if the payload contains a customer.id but does not include first_name, last_name, or email. the current logic tries to build the customer name from those fields, and when they are missing the sync   can fail before the sales order is created in the system. the fix is to fall back to the shopify customer.id during customer creation so sync can continue.

Ref: [#68402](https://support.frappe.io/helpdesk/tickets/68402)

Backport needed: v16, v15