### PR TITLE
feat(unicommerce): add date-range old-order sync with paginated fetch and duplicate-safe creation

### DIFF
--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
@@ -34,6 +34,58 @@ frappe.ui.form.on("Unicommerce Settings", {
 				__("Sync Now"),
 			);
 		});
+
+		// Backfill: sync old orders.
+		frm.add_custom_button(
+			__("Sync Old Orders"),
+			() => {
+				frappe.prompt(
+					[
+						{
+							fieldname: "from_date",
+							label: __("From Date"),
+							fieldtype: "Date",
+							reqd: 1,
+						},
+						{
+							fieldname: "to_date",
+							label: __("To Date (inclusive)"),
+							fieldtype: "Date",
+							reqd: 1,
+						},
+					],
+					(values) => {
+						if (values.to_date < values.from_date) {
+							frappe.msgprint(
+								__("To Date cannot be before From Date."),
+							);
+							return;
+						}
+						frappe.call({
+							method: "ecommerce_integrations.unicommerce.sync_old_orders.enqueue_sync_old_orders",
+							args: {
+								from_date: values.from_date,
+								to_date: values.to_date,
+							},
+							freeze: true,
+							freeze_message: __("Queuing old-order sync..."),
+							callback: (r) => {
+								if (!r.exc) {
+									frappe.msgprint(
+										__(
+											"Old-order sync queued for {0} to {1}. Track progress in the Ecommerce Integration Log.",
+											[values.from_date, values.to_date],
+										),
+									);
+								}
+							},
+						});
+					},
+					__("Sync Old Orders"),
+				);
+			},
+			__("Sync Now"),
+		);
 	},
 
 	onload: function (frm) {

--- a/ecommerce_integrations/unicommerce/sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/sync_old_orders.py
@@ -1,0 +1,261 @@
+import frappe
+from frappe import _
+from frappe.utils import add_days, getdate
+
+from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient, _utc_timeformat
+from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
+from ecommerce_integrations.unicommerce.order import _create_sales_invoices, create_order
+from ecommerce_integrations.unicommerce.utils import create_unicommerce_log
+
+SEARCH_ENDPOINT = "/services/rest/v1/oms/saleOrder/search"
+
+PAGE_SIZE = 1000
+
+LOCK_KEY = "unicommerce_sync_old_orders_running"
+JOB_ID = "unicommerce_sync_old_orders"
+
+JOB_TIMEOUT_SEC = 12 * 60 * 60
+LOCK_TTL_SEC = 13 * 60 * 60
+
+
+def _validate_date_range(from_date, to_date):
+	"""Validate dates server-side (endpoint is callable directly, not just via the JS button)."""
+	if not from_date or not to_date:
+		frappe.throw(_("Both From Date and To Date are required."))
+	from_date, to_date = getdate(from_date), getdate(to_date)
+	if from_date > to_date:
+		frappe.throw(_("From Date cannot be after To Date."))
+	if from_date > getdate():
+		frappe.throw(_("From Date cannot be in the future."))
+	return from_date, to_date
+
+
+@frappe.whitelist()
+def enqueue_sync_old_orders(from_date: str, to_date: str):
+	"""Run the old-order sync in the background `long` queue"""
+	frappe.only_for("System Manager")
+
+	from_date, to_date = _validate_date_range(from_date, to_date)
+
+	if frappe.cache().get_value(LOCK_KEY):
+		frappe.throw(_("A sync is already running. Please wait for it to finish."))
+
+	# deduplicate + job_id atomically refuses a second job that is already queued/started.
+	enqueued = frappe.enqueue(
+		"ecommerce_integrations.unicommerce.sync_old_orders.sync_old_orders",
+		queue="long",
+		timeout=JOB_TIMEOUT_SEC,
+		job_id=JOB_ID,
+		deduplicate=True,
+		from_date=from_date,
+		to_date=to_date,
+	)
+	if enqueued is None:
+		frappe.throw(_("A sync is already queued. Please wait for it to finish."))
+	return f"Old-order sync queued for {from_date} -> {to_date}"
+
+
+def sync_old_orders(from_date, to_date, client=None):
+	"""Fetch every order CREATED in [from_date, to_date) and sync the missing ones."""
+	settings = frappe.get_cached_doc(SETTINGS_DOCTYPE)
+	if not settings.is_enabled():
+		return {"error": "Unicommerce integration is disabled"}
+
+	# --- single-run guard: block a second concurrent sync ---
+	if frappe.cache().get_value(LOCK_KEY):
+		return {"error": "A sync is already running. Please wait for it to finish."}
+	frappe.cache().set_value(LOCK_KEY, 1, expires_in_sec=LOCK_TTL_SEC)
+	try:
+		return _run_sync(settings, from_date, to_date, client)
+	finally:
+		frappe.cache().delete_value(LOCK_KEY)
+
+
+def _run_sync(settings, from_date, to_date, client=None):
+	"""Core sync loop. Runs under the single-run lock held by sync_old_orders."""
+	if client is None:
+		client = UnicommerceAPIClient()
+
+	frappe.set_user("Administrator")  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
+	completed_mode = bool(settings.only_sync_completed_orders)
+	status = "COMPLETE" if completed_mode else None
+	enabled_channels = set(
+		frappe.get_all("Unicommerce Channel", filters={"enabled": 1}, pluck="channel_id", limit=0)
+	)
+
+	summary = {
+		"range": f"{from_date} -> {to_date}",
+		"total_reported": None,
+		"fetched": 0,
+		"created": 0,
+		"skipped_existing": 0,
+		"off_channel": 0,
+		"failed": 0,
+		"incomplete": False,
+	}
+
+	for page in _fetch_orders_in_range(client, from_date, to_date, status, summary):
+		existing = set(
+			frappe.get_all(
+				"Sales Order",
+				filters={ORDER_CODE_FIELD: ["in", [o["code"] for o in page]]},
+				pluck=ORDER_CODE_FIELD,
+			)
+		)
+
+		for order_summary in page:
+			code = order_summary["code"]
+			summary["fetched"] += 1
+
+			if order_summary.get("channel") not in enabled_channels:
+				summary["off_channel"] += 1
+				continue
+
+			# If the SO already exists with not completed status, will be skipped.
+			existing_so = code in existing
+			if existing_so and not completed_mode:
+				summary["skipped_existing"] += 1
+				continue
+
+			try:
+				detail = client.get_sales_order(order_code=code)
+				if not detail:
+					summary["failed"] += 1
+					continue
+
+				# create_order is self-contained: it de-dupes, logs, commits on
+				# success and rolls back its own partial work on failure.
+				sales_order = create_order(detail, client=client)
+				if sales_order is None:
+					summary["failed"] += 1
+					continue
+
+				if completed_mode:
+					_create_sales_invoices(detail, sales_order, client)
+
+				# Count only after the order (and its invoice) is fully handled, so a
+				# late failure lands in `failed` instead of double-counting this order.
+				if existing_so:
+					summary["skipped_existing"] += 1
+				else:
+					summary["created"] += 1
+			except Exception as e:
+				summary["failed"] += 1
+				create_unicommerce_log(status="Error", exception=e, rollback=True, make_new=True)
+
+	_log_summary(summary)
+	return summary
+
+
+def _fetch_orders_in_range(client, from_date, to_date, status, summary):
+	"""Yield each page of UNIQUE orders (each with a valid code) in the date range."""
+	# Pad ±1 day (intentional): makes toDate inclusive and absorbs the UTC timezone shift.
+	# May include a few orders just outside the range; de-dup keeps it safe.
+	from_padded = add_days(from_date, -1)
+	to_padded = add_days(to_date, 1)
+
+	base_body = {
+		"fromDate": _utc_timeformat(from_padded),
+		"toDate": _utc_timeformat(to_padded),
+		"dateType": "CREATED",
+	}
+	if status:
+		base_body["status"] = status
+
+	display_start = 0
+	total_records = None
+	seen = set()
+
+	while True:
+		body = dict(base_body)
+		body["searchOptions"] = {
+			"displayStart": display_start,
+			"displayLength": PAGE_SIZE,
+			"getCount": display_start == 0,
+		}
+
+		resp, ok = _request_with_retry(client, body)
+		if not ok or resp is None:
+			summary["incomplete"] = True
+			create_unicommerce_log(
+				status="Error",
+				make_new=True,
+				message=(
+					f"Old-order sync search FAILED at displayStart={display_start} "
+					f"for range. Already-created orders are safe. "
+					f"Re-run the same range to resume."
+				),
+			)
+			return
+
+		if display_start == 0:
+			total_records = resp.get("totalRecords")
+			summary["total_reported"] = total_records
+			create_unicommerce_log(
+				status="Success",
+				make_new=True,
+				message=f"Old-order sync: Unicommerce reports {total_records} orders in this range.",
+			)
+
+		elements = resp.get("elements") or []
+		if not elements:
+			return
+
+		new_page = []
+		for element in elements:
+			code = element.get("code")
+			if code and code not in seen:
+				seen.add(code)
+				new_page.append(element)  # only NEW, valid orders
+
+		# Stall guard: a full page with ZERO new orders means the API ignored
+		if not new_page:
+			summary["incomplete"] = True
+			create_unicommerce_log(
+				status="Error",
+				make_new=True,
+				message=(
+					f"Old-order sync STALLED at displayStart={display_start}: page returned "
+					f"no new orders (pagination not advancing). Check the API / re-run."
+				),
+			)
+			return
+
+		yield new_page
+
+		display_start += len(elements)
+
+		# Stop once the reported total is reached
+		if total_records is not None and display_start >= total_records:
+			return
+
+
+def _request_with_retry(client, body, attempts=3):
+	"""POST to the search endpoint, retrying a few times on transient failure."""
+	resp, ok = None, False
+	for attempt in range(attempts):
+		is_last_attempt = attempt == attempts - 1
+		# Treat an unexpected raise as a failed attempt so it doesn't abort the backfill unlogged.
+		try:
+			resp, ok = client.request(endpoint=SEARCH_ENDPOINT, body=body, log_error=is_last_attempt)
+		except Exception:
+			resp, ok = None, False
+		if ok and resp is not None:
+			return resp, True
+	return resp, ok
+
+
+def _log_summary(summary):
+	incomplete = summary.get("incomplete")
+	headline = "INCOMPLETE — re-run this range" if incomplete else "complete"
+	status = "Error" if incomplete else "Success"
+	message = (
+		f"Unicommerce old-order sync {headline} for {summary['range']}\n"
+		f"  Reported by Unicommerce : {summary['total_reported']}\n"
+		f"  Orders walked           : {summary['fetched']}\n"
+		f"  Created (new)           : {summary['created']}\n"
+		f"  Skipped (already synced): {summary['skipped_existing']}\n"
+		f"  Skipped (off-channel)   : {summary['off_channel']}\n"
+		f"  Failed                  : {summary['failed']}"
+	)
+	create_unicommerce_log(status=status, make_new=True, message=message)

--- a/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
@@ -1,0 +1,250 @@
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.utils import add_days, getdate
+
+try:  # frappe >= v16
+	from frappe.tests import IntegrationTestCase
+except ImportError:  # frappe v15
+	from frappe.tests.utils import FrappeTestCase as IntegrationTestCase
+
+from ecommerce_integrations.unicommerce import sync_old_orders as sof
+from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD
+
+SOF = "ecommerce_integrations.unicommerce.sync_old_orders"
+
+
+def _page(codes, total=None):
+	"""Build a fake search response page (frappe._dict like the real client returns)."""
+	return frappe._dict({"elements": [{"code": c} for c in codes], "totalRecords": total})
+
+
+class TestFetchOrdersInRange(IntegrationTestCase):
+	"""Unit tests for the paginated fetch generator (the new pagination logic)."""
+
+	def _fetch(self, client, status=None):
+		# _fetch_orders_in_range yields one PAGE (list of elements) per iteration;
+		# flatten to a single list of codes for easy assertions.
+		summary = {"total_reported": None, "incomplete": False}
+		with patch.object(sof, "create_unicommerce_log"):
+			pages = list(sof._fetch_orders_in_range(client, "2026-04-01", "2026-04-30", status, summary))
+		return summary, [e["code"] for page in pages for e in page]
+
+	def test_walks_all_pages_and_dedupes(self):
+		client = MagicMock()
+		p1 = _page([f"O{i}" for i in range(1000)], total=1500)
+		p2 = _page([f"O{i}" for i in range(1000, 1500)], total=1500)
+		client.request.side_effect = [(p1, True), (p2, True)]
+
+		summary, codes = self._fetch(client)
+
+		self.assertEqual(len(codes), 1500)
+		self.assertEqual(len(set(codes)), 1500)  # all unique
+		self.assertEqual(summary["total_reported"], 1500)
+		self.assertFalse(summary["incomplete"])
+		# stops exactly at total -> no wasted 3rd page request
+		self.assertEqual(client.request.call_count, 2)
+
+	def test_empty_page_stops_cleanly(self):
+		client = MagicMock()
+		client.request.return_value = (_page([], total=0), True)
+
+		summary, codes = self._fetch(client)
+
+		self.assertEqual(codes, [])
+		self.assertEqual(summary["total_reported"], 0)
+		self.assertFalse(summary["incomplete"])
+
+	def test_search_failure_flags_incomplete(self):
+		client = MagicMock()
+		client.request.return_value = (None, False)  # fails every retry
+
+		summary, codes = self._fetch(client)
+
+		self.assertEqual(codes, [])
+		self.assertTrue(summary["incomplete"])
+
+	def test_stall_guard_on_non_advancing_api(self):
+		# Same page returned twice -> 0 new on the 2nd page -> must stop + flag incomplete.
+		client = MagicMock()
+		page = _page(["A", "B"], total=None)
+		client.request.side_effect = [(page, True), (page, True)]
+
+		summary, codes = self._fetch(client)
+
+		self.assertEqual(codes, ["A", "B"])  # only the first page's new codes
+		self.assertTrue(summary["incomplete"])
+
+	def test_skips_codeless_elements(self):
+		client = MagicMock()
+		bad = frappe._dict({"elements": [{"code": "A"}, {"code": None}, {"code": ""}], "totalRecords": None})
+		client.request.side_effect = [(bad, True), (_page([], total=None), True)]
+
+		summary, codes = self._fetch(client)
+
+		self.assertEqual(codes, ["A"])  # None / "" are skipped
+
+
+class TestRequestWithRetry(IntegrationTestCase):
+	def test_succeeds_after_transient_failures(self):
+		client = MagicMock()
+		client.request.side_effect = [(None, False), (None, False), ({"ok": 1}, True)]
+
+		resp, ok = sof._request_with_retry(client, {})
+
+		self.assertTrue(ok)
+		self.assertEqual(resp, {"ok": 1})
+		self.assertEqual(client.request.call_count, 3)
+
+	def test_logs_real_error_only_on_last_attempt(self):
+		client = MagicMock()
+		client.request.return_value = (None, False)
+
+		sof._request_with_retry(client, {}, attempts=3)
+
+		log_flags = [c.kwargs.get("log_error") for c in client.request.call_args_list]
+		self.assertEqual(log_flags, [False, False, True])
+
+
+class TestLogSummary(IntegrationTestCase):
+	def _summary(self, incomplete):
+		return {
+			"range": "2026-04-01 -> 2026-04-30",
+			"total_reported": 10,
+			"fetched": 10,
+			"created": 9,
+			"skipped_existing": 1,
+			"off_channel": 0,
+			"failed": 0,
+			"incomplete": incomplete,
+		}
+
+	def test_incomplete_reported_as_error(self):
+		with patch.object(sof, "create_unicommerce_log") as log:
+			sof._log_summary(self._summary(incomplete=True))
+		kwargs = log.call_args.kwargs
+		self.assertEqual(kwargs["status"], "Error")
+		self.assertIn("INCOMPLETE", kwargs["message"])
+
+	def test_complete_reported_as_success(self):
+		with patch.object(sof, "create_unicommerce_log") as log:
+			sof._log_summary(self._summary(incomplete=False))
+		kwargs = log.call_args.kwargs
+		self.assertEqual(kwargs["status"], "Success")
+		self.assertIn("complete", kwargs["message"])
+
+
+class TestRunSyncOrchestration(IntegrationTestCase):
+	"""Verifies the per-order routing/counting in _run_sync without hitting the DB."""
+
+	def test_counts_created_skipped_and_off_channel(self):
+		client = MagicMock()
+		client.get_sales_order.return_value = {"code": "X", "status": "COMPLETE"}
+
+		settings = MagicMock()
+		settings.only_sync_completed_orders = False  # -> existing SOs skipped early
+
+		orders = [
+			{"code": "NEW1", "channel": "SHOPIFY"},  # new -> created
+			{"code": "OFF", "channel": "AMAZON"},  # off-channel -> skipped
+			{"code": "EXIST", "channel": "SHOPIFY"},  # already synced -> skipped
+		]
+
+		def fake_fetch(client, fr, to, status, summary):
+			summary["total_reported"] = len(orders)
+			yield orders  # a single page holding every order
+
+		def fake_get_all(doctype, **kwargs):
+			# _run_sync makes two pluck queries: enabled channels, and existing SOs.
+			if doctype == "Unicommerce Channel":
+				return ["SHOPIFY"]
+			if doctype == "Sales Order":
+				page_codes = kwargs["filters"][ORDER_CODE_FIELD][1]
+				return [c for c in page_codes if c == "EXIST"]
+			return []
+
+		with (
+			patch.object(sof, "_fetch_orders_in_range", side_effect=fake_fetch),
+			patch.object(sof, "create_order", return_value=MagicMock()) as create_order,
+			patch.object(sof, "_create_sales_invoices"),
+			patch.object(sof, "_log_summary"),
+			patch(f"{SOF}.frappe.set_user"),
+			patch(f"{SOF}.frappe.get_all", side_effect=fake_get_all),
+		):
+			summary = sof._run_sync(settings, "2026-04-01", "2026-04-30", client=client)
+
+		self.assertEqual(summary["fetched"], 3)
+		self.assertEqual(summary["off_channel"], 1)
+		self.assertEqual(summary["created"], 1)
+		self.assertEqual(summary["skipped_existing"], 1)
+		self.assertEqual(summary["failed"], 0)
+		create_order.assert_called_once()  # only the NEW order gets created
+
+
+class TestValidateDateRange(IntegrationTestCase):
+	"""Server-side date validation for the whitelisted endpoint (#2)."""
+
+	def test_valid_past_range_normalized_to_dates(self):
+		fr, to = sof._validate_date_range("2020-01-01", "2020-01-31")
+		self.assertEqual((fr, to), (getdate("2020-01-01"), getdate("2020-01-31")))
+
+	def test_missing_date_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			sof._validate_date_range(None, "2020-01-31")
+		with self.assertRaises(frappe.ValidationError):
+			sof._validate_date_range("2020-01-01", "")
+
+	def test_from_after_to_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			sof._validate_date_range("2020-02-01", "2020-01-01")
+
+	def test_future_from_date_throws(self):
+		future = add_days(getdate(), 5)
+		with self.assertRaises(frappe.ValidationError):
+			sof._validate_date_range(future, future)
+
+
+class TestEnqueueGuards(IntegrationTestCase):
+	"""Atomic dedup + lock guards on enqueue_sync_old_orders (#1)."""
+
+	def _enqueue(self, cache_val, enqueue_ret):
+		cache = MagicMock()
+		cache.get_value.return_value = cache_val
+		with (
+			patch(f"{SOF}.frappe.only_for"),
+			patch(f"{SOF}.frappe.cache", return_value=cache),
+			patch(f"{SOF}.frappe.enqueue", return_value=enqueue_ret) as enqueue,
+		):
+			result = sof.enqueue_sync_old_orders("2020-01-01", "2020-01-31")
+		return result, enqueue
+
+	def test_enqueues_with_dedup_and_job_id(self):
+		result, enqueue = self._enqueue(cache_val=None, enqueue_ret=MagicMock())
+		enqueue.assert_called_once()
+		kwargs = enqueue.call_args.kwargs
+		self.assertTrue(kwargs["deduplicate"])  # atomic guard is armed
+		self.assertEqual(kwargs["job_id"], sof.JOB_ID)
+		self.assertEqual(kwargs["queue"], "long")
+		self.assertIn("2020-01-01", result)
+
+	def test_blocked_while_running(self):
+		# lock held -> friendly throw, never reaches enqueue
+		with self.assertRaises(frappe.ValidationError):
+			self._enqueue(cache_val=1, enqueue_ret=MagicMock())
+
+	def test_blocked_when_duplicate_job_queued(self):
+		# enqueue() returns None (dedup skipped an already-queued job) -> throw
+		with self.assertRaises(frappe.ValidationError):
+			self._enqueue(cache_val=None, enqueue_ret=None)
+
+	def test_invalid_dates_rejected_before_enqueue(self):
+		cache = MagicMock()
+		cache.get_value.return_value = None
+		with (
+			patch(f"{SOF}.frappe.only_for"),
+			patch(f"{SOF}.frappe.cache", return_value=cache),
+			patch(f"{SOF}.frappe.enqueue") as enqueue,
+			self.assertRaises(frappe.ValidationError),
+		):
+			sof.enqueue_sync_old_orders("2020-02-01", "2020-01-01")  # inverted range
+		enqueue.assert_not_called()


### PR DESCRIPTION
## Description
  This PR adds an on-demand backfill that fetches every Unicommerce order created in a chosen date range and syncs the ones ERPNext is missing. It is triggered by a System Manager, runs on the background
  **long** queue, and is fully additive.

  ## Issues
  - The live sync (`sync_new_orders`) only looks at orders updated in the last 24 hours and has no pagination.
  - Orders outside that window — scheduler paused, a run failed midway, or a burst exceeded one page — were never picked up, leaving large gaps.
  - There was no way to recover missed orders short of manual intervention.
  - Concurrent triggers could start overlapping runs and create duplicate work.

  ## Fixes
  - Added a System Manager–triggered **"Sync Old Orders"** backfill on the long queue.
  - **Paginated fetch** over the documented `saleOrder/search` API (`fromDate`, `toDate`, `dateType=CREATED`; `searchOptions` with `displayStart`, `displayLength`, `getCount`), 1000 orders per page, walking the
  full result set.
  - **Idempotent and resumable** — existing Sales Orders are skipped, a missing invoice is created for an already-synced completed order, and re-running a failed range resumes safely.
  - **Robust termination** — stops on the reported total, an empty page, or a stall guard (a page with zero new orders is flagged incomplete instead of looping).
  - **Atomic job dedup** (`job_id` with `deduplicate=True`) plus a single-run lock so a second run cannot overlap.

  ## Key Changes
  - New `sync_old_orders.py`: `enqueue_sync_old_orders`, `sync_old_orders`, `_run_sync`, `_fetch_orders_in_range`, `_request_with_retry`, `_log_summary`.
  - **"Sync Old Orders" button** on Unicommerce Settings with a From/To date prompt.
  - **Batched per-page** existing-Sales-Order lookup and `getCount` only on the first page to minimise API and DB round-trips.
  - **Complete summary log**: reported, walked, created, skipped, off-channel, and failed counts, marked `INCOMPLETE` when a range needs re-running.
  - **21 unit tests** covering pagination, dedup, stall guard, request retry, summary logging, per-order orchestration counts, enqueue guards, and date validation — all passing.
  - **Validated on staging** across a multi-day range: created missing orders and skipped already-synced ones.

  ## Notes
  - Requires the companion **token-refresh fix** so a multi-hour backfill survives access-token expiry mid-run — will be addressed in a follow-up PR.

Backport needed in v15
