### PR TITLE
fix: map PY state to Puducherry to match ERPNext state list

### DIFF
--- a/ecommerce_integrations/unicommerce/constants.py
+++ b/ecommerce_integrations/unicommerce/constants.py
@@ -332,7 +332,7 @@ UNICOMMERCE_INDIAN_STATES_MAPPING = {
 	"MZ": "Mizoram",
 	"NL": "Nagaland",
 	"OR": "Odisha",
-	"PY": "Pondicherry",
+	"PY": "Puducherry",
 	"PB": "Punjab",
 	"RJ": "Rajasthan",
 	"SK": "Sikkim",


### PR DESCRIPTION
## Description
  Corrects the Unicommerce → ERPNext state mapping for Puducherry so orders shipping there pass address/state validation.

  ## Issue
  - The `PY` entry in `UNICOMMERCE_INDIAN_STATES_MAPPING` returned `"Pondicherry"`, but ERPNext's India state list uses the official name `"Puducherry"`.
  - As a result, orders with a Puducherry shipping/billing address failed state validation and did not sync cleanly.

  ## Fix
  - Updated the `PY` mapping from `"Pondicherry"` to `"Puducherry"` in `constants.py` to match ERPNext's state list exactly.

  ## Impact
  - One-line data mapping change; no logic or schema changes.
  - Puducherry orders now map to a valid ERPNext state and sync without validation errors.
  
 Backport needed in v15