### PR TITLE
ci: derive payments branch from CI branch instead of hardcoding develop

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -10,6 +10,10 @@ sudo apt-get -y install redis-server libcups2-dev mariadb-client -qq
 
 pip install frappe-bench
 
+# Derive branches from the CI branch so satellite apps match the bench being tested.
+githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
+paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
+
 git clone https://github.com/frappe/frappe --branch version-15 --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
@@ -32,7 +36,7 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app payments --branch develop
+bench get-app payments --branch "$paymentsbranch"
 bench get-app erpnext --branch version-15
 bench get-app ecommerce_integrations "${GITHUB_WORKSPACE}"
 


### PR DESCRIPTION
  ## Description
 
  The version-15 CI installs `frappe/payments` from the `develop` branch, which now requires **Python 3.14**. The version-15 bench runs on **Python 3.10**, so the install fails and the Python Unit Tests job dies
  before any test runs — blocking every version-15 PR:

  ```
  payments==0.0.1 depends on Python>=3.14 ... requirements are unsatisfiable.
  Error: Process completed with exit code 167
  ```

  ## Fix 

  Derive the branch from the CI branch and use it for `payments` instead of hardcoding `develop` (same pattern as the `develop` branch's `install.sh`):

  ```bash
  githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
  paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
  ...
  bench get-app payments --branch "$paymentsbranch"
  ```

  On version-15 CI this resolves to `payments@version-15` (which exists and supports Python 3.10), so the app installs and the suite runs.

  ## Notes
 
  - Only `.github/helper/install.sh` changed — CI config only, no application code.
  - `bash -n` passes; `frappe/payments` has a `version-15` branch so the branch resolves.