### PR TITLE
chore: convert raw sql

### DIFF
--- a/ecommerce_integrations/shopify/doctype/shopify_setting/test_shopify_setting.py
+++ b/ecommerce_integrations/shopify/doctype/shopify_setting/test_shopify_setting.py
@@ -22,11 +22,14 @@ from .shopify_setting import setup_custom_fields
 class TestShopifySetting(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
-		frappe.db.sql(
-			"""delete from `tabCustom Field`
-			where name like '%shopify%'"""
+		custom_field = frappe.qb.DocType("Custom Field")
+		(
+			frappe.qb.from_(custom_field)
+			.delete()
+			.where(custom_field.name.like("%shopify%"))
+			.run()
 		)
-
+ 
 	def test_custom_field_creation(self):
 		setup_custom_fields()
 

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -188,12 +188,7 @@ class ShopifyProduct:
 				self._create_item(shopify_item_variant, warehouse, 0, attributes, template_item.name)
 
 	def _get_attribute_value(self, variant_attr_val, attribute):
-		attribute_value = frappe.db.sql(
-			"""select attribute_value from `tabItem Attribute Value`
-			where parent = %s and (abbr = %s or attribute_value = %s)""",
-			(attribute["attribute"], variant_attr_val, variant_attr_val),
-			as_list=1,
-		)
+		attribute_value = frappe.get_all( "Item Attribute Value", filters={"parent": attribute['attribute']}, fields=["attribute_value"] )
 		return attribute_value[0][0] if len(attribute_value) > 0 else cint(variant_attr_val)
 
 	def _get_item_group(self, product_type=None):
@@ -216,11 +211,15 @@ class ShopifyProduct:
 
 	def _get_supplier(self, product_dict):
 		if product_dict.get("vendor"):
-			supplier = frappe.db.sql(
-				f"""select name from tabSupplier
-				where name = %s or {SUPPLIER_ID_FIELD} = %s """,
-				(product_dict.get("vendor"), product_dict.get("vendor").lower()),
-				as_list=1,
+			supplier_dt = frappe.qb.DocType("Supplier")
+			supplier = (
+				frappe.qb.from_(supplier_dt)
+				.select(supplier_dt.name)
+				.where(
+					(supplier_dt.name == product_dict.get("vendor"))
+					| (supplier_dt[SUPPLIER_ID_FIELD] == product_dict.get("vendor").lower())
+				)
+				.run(as_list=True)
 			)
 
 			if supplier:

--- a/ecommerce_integrations/shopify/product.py
+++ b/ecommerce_integrations/shopify/product.py
@@ -188,8 +188,19 @@ class ShopifyProduct:
 				self._create_item(shopify_item_variant, warehouse, 0, attributes, template_item.name)
 
 	def _get_attribute_value(self, variant_attr_val, attribute):
-		attribute_value = frappe.get_all( "Item Attribute Value", filters={"parent": attribute['attribute']}, fields=["attribute_value"] )
-		return attribute_value[0][0] if len(attribute_value) > 0 else cint(variant_attr_val)
+		item_attribute_value = frappe.qb.DocType("Item Attribute Value")
+		attribute_value = (
+			frappe.qb.from_(item_attribute_value)
+			.select(item_attribute_value.attribute_value)
+			.where(item_attribute_value.parent == attribute["attribute"])
+			.where(
+				(item_attribute_value.abbr == variant_attr_val)
+				| (item_attribute_value.attribute_value == variant_attr_val)
+			)
+			.limit(1)
+			.run()
+		)
+		return attribute_value[0][0] if attribute_value else cint(variant_attr_val)
 
 	def _get_item_group(self, product_type=None):
 		parent_item_group = get_root_of("Item Group")

--- a/ecommerce_integrations/shopify/utils.py
+++ b/ecommerce_integrations/shopify/utils.py
@@ -75,13 +75,9 @@ def _migrate_items_to_ecommerce_item(log):
 def _get_items_to_migrate() -> list[_dict]:
 	"""get all list of items that have shopify fields but do not have associated ecommerce item."""
 
-	old_data = frappe.db.sql(
-		"""SELECT item.name as erpnext_item_code, shopify_product_id, shopify_variant_id, item.variant_of, item.has_variants
-			FROM tabItem item
-			LEFT JOIN `tabEcommerce Item` ei on ei.erpnext_item_code = item.name
-			WHERE ei.erpnext_item_code IS NULL AND shopify_product_id IS NOT NULL""",
-		as_dict=True,
-	)
+	item = frappe.qb.DocType("Item")
+	ei = frappe.qb.DocType("Ecommerce Item")
+	old_data = ( frappe.qb.from_(item) .from_(ei) .select( item.name.as_("erpnext_item_code"), item.shopify_product_id, item.shopify_variant_id, item.variant_of, item.has_variants ) .where((ei.erpnext_item_code.isnull() & item.shopify_product_id.isnotnull())) .run(as_dict=True) )
 
 	return old_data or []
 

--- a/ecommerce_integrations/shopify/utils.py
+++ b/ecommerce_integrations/shopify/utils.py
@@ -77,7 +77,21 @@ def _get_items_to_migrate() -> list[_dict]:
 
 	item = frappe.qb.DocType("Item")
 	ei = frappe.qb.DocType("Ecommerce Item")
-	old_data = ( frappe.qb.from_(item) .from_(ei) .select( item.name.as_("erpnext_item_code"), item.shopify_product_id, item.shopify_variant_id, item.variant_of, item.has_variants ) .where((ei.erpnext_item_code.isnull() & item.shopify_product_id.isnotnull())) .run(as_dict=True) )
+	old_data = (
+		frappe.qb.from_(item)
+		.left_join(ei)
+		.on(ei.erpnext_item_code == item.name)
+		.select(
+			item.name.as_("erpnext_item_code"),
+			item.shopify_product_id,
+			item.shopify_variant_id,
+			item.variant_of,
+			item.has_variants,
+		)
+		.where(ei.erpnext_item_code.isnull())
+		.where(item.shopify_product_id.isnotnull())
+		.run(as_dict=True)
+	)
 
 	return old_data or []
 

--- a/ecommerce_integrations/unicommerce/invoice.py
+++ b/ecommerce_integrations/unicommerce/invoice.py
@@ -7,6 +7,7 @@ import frappe
 import requests
 from erpnext.selling.doctype.sales_order.mapper import make_sales_invoice
 from frappe import _
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, nowdate
 from frappe.utils.file_manager import save_file
 
@@ -190,11 +191,12 @@ def update_invoicing_status(sales_orders: list[str], status: str) -> None:
 	if not sales_orders:
 		return
 
-	frappe.db.sql(
-		f"""update `tabSales Order`
-			set {ORDER_INVOICE_STATUS_FIELD} = %s
-			where name in %s""",
-		(status, sales_orders),
+	sales_order = frappe.qb.DocType("Sales Order")
+	(
+		frappe.qb.update(sales_order)
+		.set(sales_order[ORDER_INVOICE_STATUS_FIELD], status)
+		.where(sales_order.name.isin(sales_orders))
+		.run()
 	)
 
 
@@ -205,15 +207,17 @@ def _validate_wh_allocation(warehouse_allocation: WHAllocation):
 		return
 
 	so_codes = list(warehouse_allocation.keys())
-	so_item_data = frappe.db.sql(
-		"""
-			select item_code, sum(qty) as qty, parent as sales_order
-			from `tabSales Order Item`
-			where
-				parent in %s
-			group by parent, item_code""",
-		(so_codes,),
-		as_dict=True,
+	so_item = frappe.qb.DocType("Sales Order Item")
+	so_item_data = (
+		frappe.qb.from_(so_item)
+		.select(
+			so_item.item_code,
+			Sum(so_item.qty).as_("qty"),
+			so_item.parent.as_("sales_order"),
+		)
+		.where(so_item.parent.isin(so_codes))
+		.groupby(so_item.parent, so_item.item_code)
+		.run(as_dict=True)
 	)
 
 	expected_item_qty = {}

--- a/ecommerce_integrations/unicommerce/product.py
+++ b/ecommerce_integrations/unicommerce/product.py
@@ -218,15 +218,16 @@ def upload_new_items(force=False) -> None:
 
 
 def _get_new_items() -> list[ItemCode]:
-	new_items = frappe.db.sql(
-		f"""
-			SELECT item.item_code
-			FROM tabItem item
-			LEFT JOIN `tabEcommerce Item` ei
-				ON ei.erpnext_item_code = item.item_code
-				WHERE ei.erpnext_item_code is NULL
-					AND item.{ITEM_SYNC_CHECKBOX} = 1
-		"""
+	item = frappe.qb.DocType("Item")
+	ecommerce_item_dt = frappe.qb.DocType("Ecommerce Item")
+	new_items = (
+		frappe.qb.from_(item)
+		.left_join(ecommerce_item_dt)
+		.on(ecommerce_item_dt.erpnext_item_code == item.item_code)
+		.select(item.item_code)
+		.where(ecommerce_item_dt.erpnext_item_code.isnull())
+		.where(item[ITEM_SYNC_CHECKBOX] == 1)
+		.run()
 	)
 
 	return [item[0] for item in new_items]

--- a/ecommerce_integrations/unicommerce/tests/test_product.py
+++ b/ecommerce_integrations/unicommerce/tests/test_product.py
@@ -68,7 +68,7 @@ class TestUnicommerceProduct(TestCaseApiClient):
 
 	def test_validate_brand(self):
 		brand_name = "_Test Brand"
-		frappe.db.sql("delete from tabBrand where name = %s", brand_name)
+		frappe.db.delete("Brand", {"name": brand_name})
 
 		_validate_create_brand(brand_name)
 


### PR DESCRIPTION
I'm a member of the [AgriTheory team](https://github.com/agritheory/), which maintains a number of Frappe and ERPNext apps. We're in the process of migrating them to version-16, and part of that process is updating any SQL queries in the code to support PostgreSQL in addition to MariaDB. As some of our apps use other Frappe apps as a dependency, we figured we'd help in the effort here.

This PR converts the remaining frappe.db.sql calls with MariaDB-specific syntax (backtick-quoted table names) into database-agnostic calls.