### PR TITLE
fix(unicommerce): cap old-order sync at 31 inclusive days with precise day bounds and tests

### DIFF
--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.js
@@ -61,6 +61,23 @@ frappe.ui.form.on("Unicommerce Settings", {
 							);
 							return;
 						}
+						// Match server MAX_SELECTABLE_RANGE_DAYS (31 inclusive calendar days).
+						const max_days = 31;
+						const from = frappe.datetime.str_to_obj(
+							values.from_date,
+						);
+						const to = frappe.datetime.str_to_obj(values.to_date);
+						const inclusive_days =
+							frappe.datetime.get_diff(to, from) + 1;
+						if (inclusive_days > max_days) {
+							frappe.msgprint(
+								__(
+									"Date range cannot be longer than {0} days.",
+									[max_days],
+								),
+							);
+							return;
+						}
 						frappe.call({
 							method: "ecommerce_integrations.unicommerce.sync_old_orders.enqueue_sync_old_orders",
 							args: {

--- a/ecommerce_integrations/unicommerce/sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/sync_old_orders.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe import _
-from frappe.utils import add_days, getdate
+from frappe.utils import date_diff, getdate
 
 from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient, _utc_timeformat
 from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
@@ -17,6 +17,9 @@ JOB_ID = "unicommerce_sync_old_orders"
 JOB_TIMEOUT_SEC = 12 * 60 * 60
 LOCK_TTL_SEC = 13 * 60 * 60
 
+# Max inclusive calendar days (e.g. 1 Jan-31 Jan = 31 days). Uni search cap is ~31 days.
+MAX_SELECTABLE_RANGE_DAYS = 31
+
 
 def _validate_date_range(from_date, to_date):
 	"""Validate dates server-side (endpoint is callable directly, not just via the JS button)."""
@@ -27,6 +30,9 @@ def _validate_date_range(from_date, to_date):
 		frappe.throw(_("From Date cannot be after To Date."))
 	if from_date > getdate():
 		frappe.throw(_("From Date cannot be in the future."))
+	# Inclusive day count: 1 Jan-31 Jan -> 31; reject anything longer.
+	if date_diff(to_date, from_date) + 1 > MAX_SELECTABLE_RANGE_DAYS:
+		frappe.throw(_("Date range cannot be longer than {0} days.").format(MAX_SELECTABLE_RANGE_DAYS))
 	return from_date, to_date
 
 
@@ -149,14 +155,10 @@ def _run_sync(settings, from_date, to_date, client=None):
 
 def _fetch_orders_in_range(client, from_date, to_date, status, summary):
 	"""Yield each page of UNIQUE orders (each with a valid code) in the date range."""
-	# Pad ±1 day (intentional): makes toDate inclusive and absorbs the UTC timezone shift.
-	# May include a few orders just outside the range; de-dup keeps it safe.
-	from_padded = add_days(from_date, -1)
-	to_padded = add_days(to_date, 1)
-
+	# Full days: start of From .. end of To. No padding, so the whole range fits the 31-day cap.
 	base_body = {
-		"fromDate": _utc_timeformat(from_padded),
-		"toDate": _utc_timeformat(to_padded),
+		"fromDate": _utc_timeformat(f"{from_date} 00:00:00"),
+		"toDate": _utc_timeformat(f"{to_date} 23:59:59"),
 		"dateType": "CREATED",
 	}
 	if status:

--- a/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
@@ -45,6 +45,20 @@ class TestFetchOrdersInRange(IntegrationTestCase):
 		# stops exactly at total -> no wasted 3rd page request
 		self.assertEqual(client.request.call_count, 2)
 
+	def test_sends_full_day_boundaries(self):
+		# No ±1-day padding: the search covers start-of-From .. end-of-To exactly.
+		client = MagicMock()
+		client.request.return_value = (_page([], total=0), True)
+		summary = {"total_reported": None, "incomplete": False}
+		with (
+			patch.object(sof, "create_unicommerce_log"),
+			patch.object(sof, "_utc_timeformat", side_effect=str),  # pass the datetime through unchanged
+		):
+			list(sof._fetch_orders_in_range(client, "2026-04-01", "2026-04-30", None, summary))
+		body = client.request.call_args.kwargs["body"]
+		self.assertEqual(body["fromDate"], "2026-04-01 00:00:00")
+		self.assertEqual(body["toDate"], "2026-04-30 23:59:59")
+
 	def test_empty_page_stops_cleanly(self):
 		client = MagicMock()
 		client.request.return_value = (_page([], total=0), True)
@@ -187,6 +201,12 @@ class TestValidateDateRange(IntegrationTestCase):
 	def test_valid_past_range_normalized_to_dates(self):
 		fr, to = sof._validate_date_range("2020-01-01", "2020-01-31")
 		self.assertEqual((fr, to), (getdate("2020-01-01"), getdate("2020-01-31")))
+
+	def test_range_over_max_throws(self):
+		# Max 31 inclusive calendar days: 1-31 OK; one day longer is rejected.
+		sof._validate_date_range("2020-01-01", "2020-01-31")  # 31 inclusive days -> ok
+		with self.assertRaises(frappe.ValidationError):
+			sof._validate_date_range("2020-01-01", "2020-02-01")  # 32 inclusive days -> throw
 
 	def test_missing_date_throws(self):
 		with self.assertRaises(frappe.ValidationError):


### PR DESCRIPTION
## Description

This PR updates the old-order sync to comply with Unicommerce's 31-day `saleOrder/search` limit by using precise date boundaries and validating the selected date range before the sync starts.

## Issues

* Old-order sync requests exceeding Unicommerce's supported search window failed with `SALE_ORDER_SEARCH_DATE_RANGE_LIMIT_EXCEEDED`.
* Date range validation occurred only after the sync reached the Unicommerce API.

## Fixes

* Used precise day boundaries for the selected date range and added upfront validation to enforce the supported search limit.
* Added unit tests for date range validation and correct day-boundary construction.
<img width="1915" height="494" alt="datefix1" src="https://github.com/user-attachments/assets/14caeead-7efb-47a4-8538-73f648123bad" />
<img width="1915" height="494" alt="datefix2 png" src="https://github.com/user-attachments/assets/89232929-335a-4d61-83c8-a322af92d0a7" />

## Key Changes

* Ensures old-order sync requests remain within Unicommerce's 31-day search limit.
* Prevents API failures by validating the date range before the sync is queued.

## Notes

* Applies only to the **Old Order Sync** flow.
* No changes to the live incremental order synchronization.

Backport needed in v15