### PR TITLE
fix/unicommerce display order and invoice fixes

### DIFF
--- a/ecommerce_integrations/unicommerce/api_client.py
+++ b/ecommerce_integrations/unicommerce/api_client.py
@@ -177,6 +177,9 @@ class UnicommerceAPIClient:
 
 		if status and "elements" in search_results:
 			return search_results["elements"]
+		else:
+			frappe.log_error("Failed to search shipping packages:", search_results)
+			return []
 
 	def get_inventory_snapshot(
 		self, sku_codes: list[str], facility_code: str, updated_since: int = 1430

--- a/ecommerce_integrations/unicommerce/delivery_note.py
+++ b/ecommerce_integrations/unicommerce/delivery_note.py
@@ -63,7 +63,7 @@ def create_delivery_note(so, sales_invoice):
 	res.unicommerce_shipment_id = sales_invoice.unicommerce_shipping_package_code
 	res.save()
 	res.submit()
-	log = create_unicommerce_log(method="create_delevery_note", make_new=True)
+	log = create_unicommerce_log(method="create_delivery_note", make_new=True)
 	frappe.flags.request_id = log.name
 	create_unicommerce_log(status="Success")
 	frappe.flags.request_id = None

--- a/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
+++ b/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py
@@ -459,6 +459,7 @@ def setup_custom_fields(update=True):
 				fieldtype="Data",
 				insert_after="unicommerce_section",
 				read_only=1,
+				search_index=1,
 			),
 			dict(
 				fieldname=ORDER_DISPLAY_CODE_FIELD,

--- a/ecommerce_integrations/unicommerce/invoice.py
+++ b/ecommerce_integrations/unicommerce/invoice.py
@@ -51,9 +51,7 @@ INVOICED_STATE = ["PACKED", "READY_TO_SHIP", "DISPATCHED", "MANIFESTED", "SHIPPE
 
 
 @frappe.whitelist()
-def generate_unicommerce_invoices(
-	sales_orders: list[SOCode], warehouse_allocation: WHAllocation | None = None
-):
+def generate_unicommerce_invoices(sales_orders: Any, warehouse_allocation: Any = None):
 	"""Request generation of invoice to Unicommerce and sync that invoice.
 
 	1. Get shipping package details using get_sale_order
@@ -153,6 +151,9 @@ def bulk_generate_invoices(
 
 
 def _log_invoice_generation(sales_orders, failed_orders):
+	if not sales_orders:
+		return
+
 	failed_orders = set(failed_orders)
 	failed_orders.update(_get_orders_with_missing_invoice(sales_orders))
 	successful_orders = list(set(sales_orders) - set(failed_orders))
@@ -162,7 +163,7 @@ def _log_invoice_generation(sales_orders, failed_orders):
 	failure_message = "\n".join(
 		[
 			f"generate invoices: {percent_success:.3%} invoices successful\n",
-			f"Failred orders = {', '.join(failed_orders)}",
+			f"Failed orders = {', '.join(failed_orders)}",
 			f"Requested orders = {', '.join(sales_orders)}",
 		]
 	)
@@ -170,7 +171,8 @@ def _log_invoice_generation(sales_orders, failed_orders):
 	update_invoicing_status(failed_orders, "Failed")
 	update_invoicing_status(successful_orders, "Success")
 
-	status = {0.0: "Failure", 100.0: "Success"}.get(percent_success) or "Partial Success"
+	# percent_success is a fraction, so the all-succeeded key is 1.0.
+	status = {0.0: "Failure", 1.0: "Success"}.get(percent_success) or "Partial Success"
 	create_unicommerce_log(status=status, message=failure_message)
 
 
@@ -189,6 +191,9 @@ def _get_orders_with_missing_invoice(sales_orders):
 def update_invoicing_status(sales_orders: list[str], status: str) -> None:
 	if not sales_orders:
 		return
+
+	# `in %s` needs a list/tuple; a set renders as its Python repr and breaks the query.
+	sales_orders = list(sales_orders)
 
 	frappe.db.sql(
 		f"""update `tabSales Order`

--- a/ecommerce_integrations/unicommerce/order.py
+++ b/ecommerce_integrations/unicommerce/order.py
@@ -134,10 +134,8 @@ def create_order(payload: UnicommerceOrder, request_id: str | None = None, clien
 		# propagate it onto the invoices / delivery notes already made from this order.
 		display_order_code = order.get("displayOrderCode")
 		if display_order_code and not so.get(ORDER_DISPLAY_CODE_FIELD):
-			# Backfill invoices / delivery notes first, then flag the order last so a
-			# failed backfill leaves it un-flagged for the next re-sync to retry.
-			_backfill_display_order_code(order["code"], display_order_code)
-			so.db_set(ORDER_DISPLAY_CODE_FIELD, display_order_code, update_modified=False)
+			backfill_display_order_code(order["code"], display_order_code)
+			so.reload()
 		return so
 
 	# If a sales order already exists, then every time it's executed
@@ -165,10 +163,14 @@ def create_order(payload: UnicommerceOrder, request_id: str | None = None, clien
 		return order
 
 
-def _backfill_display_order_code(uni_order_code: str, display_order_code: str) -> None:
-	"""Copy the display order no. onto Sales Invoices / Delivery Notes of an order
+def backfill_display_order_code(uni_order_code: str, display_order_code: str | None) -> None:
+	"""Copy the display order no. onto an order and its Sales Invoices / Delivery Notes
 	that were created before the field existed (they carry the same order code)."""
-	for doctype in ("Sales Invoice", "Delivery Note"):
+	if not display_order_code:
+		return
+
+	# Order last, so a failed backfill leaves it blank for the next re-sync to retry.
+	for doctype in ("Sales Invoice", "Delivery Note", "Sales Order"):
 		dt = frappe.qb.DocType(doctype)
 		(
 			frappe.qb.update(dt)

--- a/ecommerce_integrations/unicommerce/sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/sync_old_orders.py
@@ -4,7 +4,11 @@ from frappe.utils import date_diff, getdate
 
 from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient, _utc_timeformat
 from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
-from ecommerce_integrations.unicommerce.order import _create_sales_invoices, create_order
+from ecommerce_integrations.unicommerce.order import (
+	_create_sales_invoices,
+	backfill_display_order_code,
+	create_order,
+)
 from ecommerce_integrations.unicommerce.utils import create_unicommerce_log
 
 SEARCH_ENDPOINT = "/services/rest/v1/oms/saleOrder/search"
@@ -120,6 +124,13 @@ def _run_sync(settings, from_date, to_date, client=None):
 			# If the SO already exists with not completed status, will be skipped.
 			existing_so = code in existing
 			if existing_so and not completed_mode:
+				# The order is skipped, but its display order no. may still be missing.
+				# displayOrderCode comes from the search result, so this needs no API call.
+				# Log and move on if it fails: the order itself is already synced.
+				try:
+					backfill_display_order_code(code, order_summary.get("displayOrderCode"))
+				except Exception as e:
+					create_unicommerce_log(status="Error", exception=e, rollback=True, make_new=True)
 				summary["skipped_existing"] += 1
 				continue
 

--- a/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/tests/test_sync_old_orders.py
@@ -161,7 +161,8 @@ class TestRunSyncOrchestration(IntegrationTestCase):
 		orders = [
 			{"code": "NEW1", "channel": "SHOPIFY"},  # new -> created
 			{"code": "OFF", "channel": "AMAZON"},  # off-channel -> skipped
-			{"code": "EXIST", "channel": "SHOPIFY"},  # already synced -> skipped
+			# already synced -> skipped, but still backfilled from the search result
+			{"code": "EXIST", "channel": "SHOPIFY", "displayOrderCode": "SO-EXIST"},
 		]
 
 		def fake_fetch(client, fr, to, status, summary):
@@ -180,6 +181,7 @@ class TestRunSyncOrchestration(IntegrationTestCase):
 		with (
 			patch.object(sof, "_fetch_orders_in_range", side_effect=fake_fetch),
 			patch.object(sof, "create_order", return_value=MagicMock()) as create_order,
+			patch.object(sof, "backfill_display_order_code") as backfill,
 			patch.object(sof, "_create_sales_invoices"),
 			patch.object(sof, "_log_summary"),
 			patch(f"{SOF}.frappe.set_user"),
@@ -193,6 +195,9 @@ class TestRunSyncOrchestration(IntegrationTestCase):
 		self.assertEqual(summary["skipped_existing"], 1)
 		self.assertEqual(summary["failed"], 0)
 		create_order.assert_called_once()  # only the NEW order gets created
+
+		# Skipping an existing order must still fill in its display order no.
+		backfill.assert_called_once_with("EXIST", "SO-EXIST")
 
 
 class TestValidateDateRange(IntegrationTestCase):


### PR DESCRIPTION
## Description

   Fixes #74405 — resolves Sales Invoice generation failing with a SQL error when an order could not be invoiced, and makes the Unicommerce Display Order No. reach orders synced before the field existed.

  ## Issues

  - Generating an invoice for an order that Unicommerce rejects raised a SQL syntax error while recording the failure.
  - A fully successful invoice run was reported as "Partial Success".
  - Re-running **Sync Old Orders** did not backfill the Display Order No. — already-synced orders were skipped before the backfill could run.
  - `unicommerce_order_code` was unindexed on Delivery Note, so each backfill scanned the whole table.

  ## Fixes

  - `update_invoicing_status` coerces its argument to a list, so failed orders are recorded instead of raising.
  - Invoice run status is correct at 100% success; empty order lists no longer raise.
  - `sync_old_orders` backfills already-synced orders instead of skipping them, using the display code from the search response — no extra API call or query.
  - The backfill is guarded so a failure logs and the sweep continues, and only blank values are written, so re-running is a no-op.
  - Indexed `unicommerce_order_code` on Delivery Note.

  ## Key Changes

  - **`invoice.py`** — `update_invoicing_status` accepts sets; corrected success key (`1.0`), empty-list handling, and the "Failred orders" typo.
  - **`api_client.py`** — `search_sales_order` logs failures and returns `[]` instead of `None`.
  - **`delivery_note.py`** — Fixed the `create_delevery_note` log method typo.
  - **`sync_old_orders.py`** — Backfills Display Order No. for skipped orders, guarded so failures don't abort the sync.
  - **`order.py`** — `_backfill_display_order_code` → public `backfill_display_order_code`, extended to Sales Orders, returns early when no display code is available.
  - **`unicommerce_settings.py`** — `search_index=1` on the Delivery Note `unicommerce_order_code` field.
  - **Tests** — Verify skipped orders still receive the backfill.

  ## Notes

  - Backport Needed in version-15.
