### PR TITLE
fix/unicommerce tax returns backfill

### DIFF
--- a/ecommerce_integrations/unicommerce/api_client.py
+++ b/ecommerce_integrations/unicommerce/api_client.py
@@ -453,6 +453,50 @@ class UnicommerceAPIClient:
 		if statuses and "elements" in search_results:
 			return search_results["elements"]
 
+	def get_return_details(
+		self,
+		reverse_pickup_code: str | None = None,
+		shipment_code: str | None = None,
+		facility_code: str | None = None,
+	) -> JsonDict | None:
+		"""Get return details using reverse pickup code or shipping package code.
+
+		Provides accurate return creation date via returnSaleOrderValue.returnCreatedDate.
+		Requires Facility header for authentication.
+
+		Args:
+			reverse_pickup_code: Reverse pickup code for CIR returns
+			shipment_code: Shipping package code for RTO returns
+			facility_code: Facility code (required for Return API header)
+
+		Returns:
+			Return details including returnSaleOrderValue with returnCreatedDate,
+			or None if API call fails
+
+		ref: https://documentation.unicommerce.com/docs/return-get.html
+		"""
+		body = {}
+
+		# Only include the parameter we're actually using (not null)
+		if reverse_pickup_code:
+			body["reversePickupCode"] = reverse_pickup_code
+		if shipment_code:
+			body["shipmentCode"] = shipment_code
+
+		# Facility header is required for Return API
+		extra_headers = {}
+		if facility_code:
+			extra_headers["Facility"] = facility_code
+
+		response, status = self.request(
+			endpoint="/services/rest/v1/oms/return/get",
+			body=body,
+			headers=extra_headers,
+		)
+
+		if status:
+			return response
+
 	def create_import_job(
 		self,
 		job_name: str,

--- a/ecommerce_integrations/unicommerce/api_client.py
+++ b/ecommerce_integrations/unicommerce/api_client.py
@@ -178,7 +178,7 @@ class UnicommerceAPIClient:
 		if status and "elements" in search_results:
 			return search_results["elements"]
 		else:
-			frappe.log_error("Failed to search shipping packages:", search_results)
+			frappe.log_error("Failed to search sales orders:", search_results)
 			return []
 
 	def get_inventory_snapshot(
@@ -452,6 +452,9 @@ class UnicommerceAPIClient:
 
 		if statuses and "elements" in search_results:
 			return search_results["elements"]
+		else:
+			frappe.log_error("Failed to search shipping packages:", search_results)
+			return []
 
 	def get_return_details(
 		self,

--- a/ecommerce_integrations/unicommerce/cancellation_and_returns.py
+++ b/ecommerce_integrations/unicommerce/cancellation_and_returns.py
@@ -19,6 +19,7 @@ from ecommerce_integrations.unicommerce.constants import (
 	SHIPPING_PROVIDER_CODE,
 	TRACKING_CODE_FIELD,
 )
+from ecommerce_integrations.unicommerce.utils import create_unicommerce_log, get_unicommerce_date
 
 
 def fully_cancel_orders(unicommerce_order_codes: list[str]) -> None:
@@ -108,17 +109,15 @@ def _serialize_items(trans_items) -> str:
 
 
 def create_rto_return(package_info, client: UnicommerceAPIClient):
-	"""When RTO is expected create a credit note in draft state with required details.
-
-	RTO => Return To Origin. Entire package is being returned.
-	"""
+	"""Create a credit note when RTO is expected (Return To Origin)."""
 
 	package_code = package_info["code"]
 
+	# is_return=0, else this can pick the credit note instead of the invoice
 	invoice = frappe.db.get_value(
 		"Sales Invoice",
-		{SHIPPING_PACKAGE_CODE_FIELD: package_code},
-		["name", ORDER_CODE_FIELD, CHANNEL_ID_FIELD],
+		{SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 0},
+		["name", ORDER_CODE_FIELD, CHANNEL_ID_FIELD, FACILITY_CODE_FIELD],
 		as_dict=True,
 	)
 
@@ -129,13 +128,94 @@ def create_rto_return(package_info, client: UnicommerceAPIClient):
 		return
 
 	so_data = client.get_sales_order(invoice.get(ORDER_CODE_FIELD))
+	if not so_data:
+		return
 
+	# the sweep calls us once per package that changed state
+	sync_rto_returns(
+		so_data, only_package=package_code, client=client, facility_code=invoice.get(FACILITY_CODE_FIELD)
+	)
+
+
+def sync_rto_returns(so_data, only_package=None, client=None, facility_code=None):
+	"""Create credit notes for RTO packages in the order payload.
+
+	Payload driven, so it also covers old orders outside the hourly sweep's window.
+	An RTO return `code` is the shipping package code, which links to the invoice.
+	"""
 	rto_returns = [
-		r for r in so_data["returns"] if r["type"] == "Courier Returned" and r["code"] == package_code
+		r
+		for r in so_data.get("returns", [])
+		if r["type"] == "Courier Returned" and (not only_package or r["code"] == only_package)
 	]
-	if rto_returns:
-		credit_note = create_credit_note(invoice.name)
-		credit_note.save()
+
+	for rto_return in rto_returns:
+		package_code = rto_return["code"]
+
+		# no docstatus filter: credit notes are left in draft, so submitted never matches
+		if frappe.db.exists("Sales Invoice", {SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 1}):
+			continue
+
+		# returns can only be made against a submitted invoice, never a credit note
+		invoice = frappe.db.get_value(
+			"Sales Invoice",
+			{SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 0, "docstatus": 1},
+			["name", "posting_date"],
+			as_dict=True,
+		)
+		if not invoice:
+			create_unicommerce_log(
+				status="Invalid",
+				message=(
+					f"No submitted sales invoice found for shipping package {package_code}, "
+					f"skipped RTO return on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+		# Get return creation date and full Return API response (RTO uses shipment code)
+		if not client:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Client not provided for RTO return {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+		return_timestamp, return_details = get_return_date_from_package(
+			client, shipment_code=package_code, facility_code=facility_code
+		)
+
+		# Use return API date - no fallback to invoice date
+		if not return_timestamp:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Unable to get return date from Return API for {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+		posting_date = get_unicommerce_date(return_timestamp)
+		# isolated so a failure (eg. closed period) doesn't skip the remaining packages
+		try:
+			credit_note = create_credit_note(invoice.name, posting_date=posting_date)
+			credit_note.save()
+
+			create_unicommerce_log(
+				status="Success",
+				message="RTO credit note created successfully",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+				request_data=return_details,  # Full Unicommerce Return API response
+			)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=(
+					f"Failed to create RTO credit note for shipping package {package_code} "
+					f"on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
 
 
 def get_return_warehouse(facility_code):
@@ -144,25 +224,71 @@ def get_return_warehouse(facility_code):
 	)
 
 
-def create_credit_note(invoice_name):
+def get_return_date_from_package(client, return_code=None, facility_code=None, shipment_code=None):
+	"""Get accurate return timestamp from Unicommerce Return API.
+
+	Uses the Get Return API to fetch returnSaleOrderValue.returnCreatedDate
+	which represents when the return was actually created.
+
+	Args:
+		client: UnicommerceAPIClient instance
+		return_code: Reverse pickup code for CIR returns
+		facility_code: Facility code for Return API header (required)
+		shipment_code: Shipping package code for RTO returns
+
+	Returns:
+		tuple: (timestamp in milliseconds, return_details) or (None, None)
+	"""
+	try:
+		return_details = client.get_return_details(
+			reverse_pickup_code=return_code,
+			shipment_code=shipment_code,
+			facility_code=facility_code,
+		)
+
+		if return_details and return_details.get("returnSaleOrderValue"):
+			# Return API gives datetime string, need to convert to timestamp
+			return_created_str = return_details["returnSaleOrderValue"].get("returnCreatedDate")
+			if return_created_str:
+				# Convert datetime string to timestamp (milliseconds)
+				from datetime import datetime
+
+				dt = datetime.strptime(return_created_str, "%Y-%m-%d %H:%M:%S")
+				timestamp = int(dt.timestamp() * 1000)
+				return timestamp, return_details
+
+	except Exception as e:
+		code = return_code or shipment_code
+		frappe.log_error(f"Failed to fetch return details for {code}: {e}")
+
+	return None, None
+
+
+def create_credit_note(invoice_name, posting_date=None):
 	credit_note = make_sales_return(invoice_name)
 	facility_code = credit_note.get(FACILITY_CODE_FIELD)
 	return_warehouse = get_return_warehouse(facility_code)
+
+	# Set posting date for backfilled returns so they land in the correct period
+	if posting_date:
+		credit_note.set_posting_time = 1
+		credit_note.posting_date = posting_date
 
 	for item in credit_note.items:
 		item.warehouse = return_warehouse or item.warehouse
 
 	for tax in credit_note.taxes:
-		tax.item_wise_tax_detail = json.loads(tax.item_wise_tax_detail)
-		for _item, tax_distribution in tax.item_wise_tax_detail.items():
-			tax_distribution[1] *= -1
-		tax.item_wise_tax_detail = json.dumps(tax.item_wise_tax_detail)
+		if hasattr(tax, "item_wise_tax_detail") and tax.item_wise_tax_detail:
+			tax.item_wise_tax_detail = json.loads(tax.item_wise_tax_detail)
+			for _item, tax_distribution in tax.item_wise_tax_detail.items():
+				tax_distribution[1] *= -1
+			tax.item_wise_tax_detail = json.dumps(tax.item_wise_tax_detail)
 
 	return credit_note
 
 
 def check_and_update_customer_initiated_returns(orders, client: UnicommerceAPIClient) -> None:
-	"""Create credit note if order contains customer intiated returns."""
+	"""Create credit notes for customer-initiated returns on recently updated orders."""
 
 	recently_changed_orders = _filter_recent_orders(orders)
 
@@ -170,47 +296,140 @@ def check_and_update_customer_initiated_returns(orders, client: UnicommerceAPICl
 		so_data = client.get_sales_order(order["code"])
 		if not so_data:
 			continue
-		sync_customer_initiated_returns(so_data)
+		sync_customer_initiated_returns(so_data, client)
 
 
-def sync_customer_initiated_returns(so_data):
+def sync_customer_initiated_returns(so_data, client=None):
 	customer_returns = [r for r in so_data.get("returns", []) if r["type"] == "Customer Returned"]
 	if not customer_returns:
 		return
 
 	for customer_return in customer_returns:
-		if not frappe.db.exists("Sales Invoice", {RETURN_CODE_FIELD: customer_return["code"]}):
-			create_cir_credit_note(so_data, customer_return)
+		if frappe.db.exists("Sales Invoice", {RETURN_CODE_FIELD: customer_return["code"]}):
+			continue
+
+		# isolated so a failure (eg. closed period) doesn't skip the remaining returns
+		try:
+			create_cir_credit_note(so_data, customer_return, client)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=(
+					f"Failed to create credit note for return {customer_return['code']} "
+					f"on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_customer_initiated_returns",
+			)
 
 
-def create_cir_credit_note(so_data, return_data):
+def _get_invoice_for_return(order_code, returned_so_items):
+	"""Find the invoice containing the returned items.
+
+	An order with multiple packages has multiple invoices. Picking the wrong one
+	leaves an empty credit note after _handle_partial_returns strips items.
+	"""
+	invoices = frappe.get_all(
+		"Sales Invoice",
+		filters={ORDER_CODE_FIELD: order_code, "is_return": 0, "docstatus": 1},
+		pluck="name",
+	)
+	if len(invoices) <= 1:
+		return invoices[0] if invoices else None
+
+	# single query for all invoices, else one per invoice
+	all_si_items = frappe.get_all(
+		"Sales Invoice Item",
+		filters={"parent": ["in", invoices]},
+		fields=["parent", "so_detail"],
+	)
+
+	invoice_items = {}
+	for item in all_si_items:
+		invoice_items.setdefault(item["parent"], set()).add(item["so_detail"])
+
+	for invoice_name in invoices:
+		si_so_details = invoice_items.get(invoice_name, set())
+		if returned_so_items and returned_so_items <= si_so_details:
+			return invoice_name
+
+
+def create_cir_credit_note(so_data, return_data, client=None):
 	sales_order_name = frappe.db.get_value("Sales Order", {ORDER_CODE_FIELD: so_data["code"]})
+	if not sales_order_name:
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"No sales order found for {so_data['code']}, skipped return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
 	so = frappe.get_doc("Sales Order", sales_order_name)
 
 	# Get items from SO which are returned, map SO item -> SI item with linked rows.
 	so_item_code_map = {item.get(ORDER_ITEM_CODE_FIELD): item.name for item in so.items}
 
-	invoice_name = frappe.db.get_value("Sales Invoice", {ORDER_CODE_FIELD: so_data["code"], "is_return": 0})
+	returned_so_codes = [item.get("saleOrderItemCode") for item in return_data.get("returnItems") or []]
+	returned_so_items = {so_item_code_map.get(code) for code in returned_so_codes} - {None}
+
+	invoice_name = _get_invoice_for_return(so_data["code"], returned_so_items)
+	if not invoice_name:
+		# no invoice, or the returned rows span more than one package's invoice
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"No sales invoice found for order {so_data['code']}, skipped return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
 	si = frappe.get_doc("Sales Invoice", invoice_name)
 	so_si_item_map = {item.so_detail: item.name for item in si.items}
 
-	credit_note = create_credit_note(si.name)
+	facility_code = si.get(FACILITY_CODE_FIELD)
 
+	# Initialize client if not provided
+	if not client:
+		client = UnicommerceAPIClient()
+
+	return_timestamp, return_details = get_return_date_from_package(
+		client, return_code=return_data["code"], facility_code=facility_code
+	)
+
+	# Use shipping package return date
+	if not return_timestamp:
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"Unable to get return date from Return API for {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
+	posting_date = get_unicommerce_date(return_timestamp)
+
+	credit_note = create_credit_note(si.name, posting_date=posting_date)
+
+	# return code is what the dedupe check looks up, else every run adds a draft
+	credit_note.set(RETURN_CODE_FIELD, return_data["code"])
 	credit_note.set(TRACKING_CODE_FIELD, return_data.get("trackingNumber"))
 	credit_note.set(SHIPPING_PROVIDER_CODE, return_data.get("shippingProvider"))
 
-	returned_so_codes = [item.get("saleOrderItemCode") for item in return_data.get("returnItems")]
-	returned_si_items = [so_si_item_map.get(so_item_code_map.get(code)) for code in returned_so_codes]
+	returned_si_items = [so_si_item_map.get(so_item) for so_item in returned_so_items]
 
 	if set(returned_si_items) != set(so_si_item_map.values()):
 		_handle_partial_returns(credit_note, returned_si_items)
-		pass
 
 	credit_note.save()
 
+	create_unicommerce_log(
+		status="Success",
+		message="Customer return credit note created successfully",
+		method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		request_data=return_details,  # Full Unicommerce Return API response
+	)
+
+	return credit_note
+
 
 def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
-	"""Remove non-returned item from credit note and update taxes"""
+	"""Remove non-returned items from credit note and update taxes."""
 
 	item_code_to_qty_map = defaultdict(float)
 	for item in credit_note.items:
@@ -225,6 +444,9 @@ def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
 
 	for tax in credit_note.taxes:
 		# reduce total value
+		if not (hasattr(tax, "item_wise_tax_detail") and tax.item_wise_tax_detail):
+			continue
+
 		item_wise_tax_detail = json.loads(tax.item_wise_tax_detail)
 		new_tax_amt = 0.0
 
@@ -233,7 +455,14 @@ def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
 			if not tax_distribution[1]:
 				# Ignore 0 values
 				continue
-			return_percent = returned_qty_map.get(item_code, 0.0) / item_code_to_qty_map.get(item_code)
+
+			# the breakup can name an item that isn't on this credit note
+			original_qty = item_code_to_qty_map.get(item_code) or 0.0
+			if not original_qty:
+				tax_distribution[1] = 0.0
+				continue
+
+			return_percent = returned_qty_map.get(item_code, 0.0) / original_qty
 			tax_distribution[1] *= return_percent
 			new_tax_amt += tax_distribution[1]
 

--- a/ecommerce_integrations/unicommerce/status_updater.py
+++ b/ecommerce_integrations/unicommerce/status_updater.py
@@ -52,6 +52,7 @@ def update_sales_order_status():
 		return
 
 	client = UnicommerceAPIClient()
+	frappe.set_user("Administrator")  # nosemgrep
 
 	days_to_sync = min(settings.get("order_status_days") or 2, 14)
 	minutes = days_to_sync * 24 * 60
@@ -111,6 +112,7 @@ def update_shipping_package_status():
 		return
 
 	client = UnicommerceAPIClient()
+	frappe.set_user("Administrator")  # nosemgrep
 
 	days_to_sync = min(settings.get("order_status_days") or 2, 14)
 	minutes = days_to_sync * 24 * 60

--- a/ecommerce_integrations/unicommerce/status_updater.py
+++ b/ecommerce_integrations/unicommerce/status_updater.py
@@ -94,7 +94,7 @@ def _update_order_status_fields(orders):
 
 		if old_status != new_status:
 			so_code = order["name"]
-			frappe.db.set_value("Sales Order", so_code, ORDER_STATUS_FIELD, new_status, for_update=True)
+			frappe.db.set_value("Sales Order", so_code, ORDER_STATUS_FIELD, new_status)
 
 
 def ignore_pick_list_on_sales_order_cancel(doc, method=None):
@@ -153,6 +153,4 @@ def _update_package_status_fields(packages):
 
 		if old_status != new_status:
 			si_code = invoice["name"]
-			frappe.db.set_value(
-				"Sales Invoice", si_code, SHIPPING_PACKAGE_STATUS_FIELD, new_status, for_update=True
-			)
+			frappe.db.set_value("Sales Invoice", si_code, SHIPPING_PACKAGE_STATUS_FIELD, new_status)

--- a/ecommerce_integrations/unicommerce/sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/sync_old_orders.py
@@ -3,6 +3,10 @@ from frappe import _
 from frappe.utils import date_diff, getdate
 
 from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient, _utc_timeformat
+from ecommerce_integrations.unicommerce.cancellation_and_returns import (
+	sync_customer_initiated_returns,
+	sync_rto_returns,
+)
 from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
 from ecommerce_integrations.unicommerce.order import (
 	_create_sales_invoices,
@@ -149,6 +153,8 @@ def _run_sync(settings, from_date, to_date, client=None):
 
 				if completed_mode:
 					_create_sales_invoices(detail, sales_order, client)
+					# after invoicing: the credit note is built from the invoice
+					_sync_old_returns(detail, code, client)
 
 				# Count only after the order (and its invoice) is fully handled, so a
 				# late failure lands in `failed` instead of double-counting this order.
@@ -162,6 +168,29 @@ def _run_sync(settings, from_date, to_date, client=None):
 
 	_log_summary(summary)
 	return summary
+
+
+def _sync_old_returns(detail, order_code, client=None):
+	"""Create credit notes for returns on an old order.
+
+	The hourly sweeps only see recently updated records, so old returns are synced
+	here while the order payload is in hand. Each type is isolated so one failure
+	doesn't block the other, without rolling back the order just synced.
+	"""
+	sync_functions = (
+		("customer initiated", sync_customer_initiated_returns),
+		("RTO", sync_rto_returns),
+	)
+	for return_type, sync_returns in sync_functions:
+		try:
+			sync_returns(detail, client=client)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=f"Failed to sync {return_type} returns for order {order_code}",
+			)
 
 
 def _fetch_orders_in_range(client, from_date, to_date, status, summary):

--- a/ecommerce_integrations/unicommerce/tests/fixtures/order-with-customer-return.json
+++ b/ecommerce_integrations/unicommerce/tests/fixtures/order-with-customer-return.json
@@ -1,0 +1,68 @@
+{
+  "code": "SO-CIR-001",
+  "displayOrderCode": "SO-CIR-001",
+  "channel": "RAINFOREST",
+  "status": "COMPLETE",
+  "created": 1625049926000,
+  "updated": 1625049926000,
+  "currencyCode": "INR",
+  "addresses": [
+    {
+      "id": "24006",
+      "name": "Test Customer 2",
+      "addressLine1": "456 Test Ave",
+      "city": "Delhi",
+      "state": "DL",
+      "country": "IN",
+      "pincode": "110001",
+      "phone": "8888888888"
+    }
+  ],
+  "shippingPackages": [
+    {
+      "code": "PKG-CIR-001",
+      "status": "DISPATCHED",
+      "facilityCode": "Test-123"
+    }
+  ],
+  "saleOrderItems": [
+    {
+      "code": "TEST-ITEM-002",
+      "itemSku": "TEST-ITEM-2",
+      "itemName": "Test Item 2",
+      "totalPrice": 2000.0,
+      "sellingPrice": 2000.0,
+      "quantity": 2,
+      "statusCode": "CREATED",
+      "facilityCode": "Test-123",
+      "shippingPackageCode": "PKG-CIR-001"
+    },
+    {
+      "code": "TEST-ITEM-003",
+      "itemSku": "TEST-ITEM-3",
+      "itemName": "Test Item 3",
+      "totalPrice": 1500.0,
+      "sellingPrice": 1500.0,
+      "quantity": 1,
+      "statusCode": "CREATED",
+      "facilityCode": "Test-123",
+      "shippingPackageCode": "PKG-CIR-001"
+    }
+  ],
+  "returns": [
+    {
+      "code": "RET-CIR-001",
+      "type": "Customer Returned",
+      "status": "COMPLETE",
+      "created": 1625136326000,
+      "returnDate": 1625136326000,
+      "trackingNumber": "TRACK-12345",
+      "shippingProvider": "DTDC",
+      "returnItems": [
+        {
+          "saleOrderItemCode": "TEST-ITEM-002"
+        }
+      ]
+    }
+  ]
+}

--- a/ecommerce_integrations/unicommerce/tests/fixtures/order-with-rto-return.json
+++ b/ecommerce_integrations/unicommerce/tests/fixtures/order-with-rto-return.json
@@ -1,0 +1,50 @@
+{
+  "code": "SO-RTO-001",
+  "displayOrderCode": "SO-RTO-001",
+  "channel": "RAINFOREST",
+  "status": "COMPLETE",
+  "created": 1625049926000,
+  "updated": 1625049926000,
+  "currencyCode": "INR",
+  "addresses": [
+    {
+      "id": "24005",
+      "name": "Test Customer",
+      "addressLine1": "123 Test St",
+      "city": "Mumbai",
+      "state": "MH",
+      "country": "IN",
+      "pincode": "400001",
+      "phone": "9999999999"
+    }
+  ],
+  "shippingPackages": [
+    {
+      "code": "PKG-RTO-001",
+      "status": "DISPATCHED",
+      "facilityCode": "Test-123"
+    }
+  ],
+  "saleOrderItems": [
+    {
+      "code": "TEST-ITEM-001",
+      "itemSku": "TEST-ITEM",
+      "itemName": "Test Item",
+      "totalPrice": 1000.0,
+      "sellingPrice": 1000.0,
+      "quantity": 1,
+      "statusCode": "CREATED",
+      "facilityCode": "Test-123",
+      "shippingPackageCode": "PKG-RTO-001"
+    }
+  ],
+  "returns": [
+    {
+      "code": "PKG-RTO-001",
+      "type": "Courier Returned",
+      "status": "COMPLETE",
+      "created": 1625136326000,
+      "returnDate": 1625136326000
+    }
+  ]
+}

--- a/ecommerce_integrations/unicommerce/tests/test_returns.py
+++ b/ecommerce_integrations/unicommerce/tests/test_returns.py
@@ -1,0 +1,449 @@
+"""Tests for Unicommerce return and credit note functionality."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from ecommerce_integrations.unicommerce.cancellation_and_returns import (
+	_get_invoice_for_return,
+	_handle_partial_returns,
+	sync_customer_initiated_returns,
+	sync_rto_returns,
+)
+from ecommerce_integrations.unicommerce.constants import (
+	SHIPPING_PACKAGE_CODE_FIELD,
+)
+from ecommerce_integrations.unicommerce.tests.utils import TestCase
+
+CANCELLATION_MODULE = "ecommerce_integrations.unicommerce.cancellation_and_returns"
+SYNC_OLD_ORDERS_MODULE = "ecommerce_integrations.unicommerce.sync_old_orders"
+
+
+class TestRTOReturnSync(TestCase):
+	"""Test RTO return credit note creation."""
+
+	def setUp(self):
+		super().setUp()
+		self.so_data = self.load_fixture("order-with-rto-return")
+
+	def test_skips_when_credit_note_already_exists(self):
+		"""De-duplication: skip if a credit note exists for the package."""
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+		):
+			sync_rto_returns(self.so_data)
+
+		create_cn.assert_not_called()
+
+	def test_dedupe_check_ignores_docstatus(self):
+		"""The de-dupe lookup must not filter on docstatus.
+
+		Credit notes are left in draft, so a docstatus=1 filter never matches one
+		and every run would add another duplicate.
+		"""
+		seen_filters = []
+
+		def mock_exists(doctype, filters=None, *args, **kwargs):
+			seen_filters.append(filters)
+			# a draft credit note exists: is_return row present, docstatus still 0
+			return bool(filters and filters.get("is_return") == 1)
+
+		with (
+			patch("frappe.db.exists", side_effect=mock_exists),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+		):
+			sync_rto_returns(self.so_data)
+
+		dedupe_filters = [
+			f
+			for f in seen_filters
+			if f and f.get("is_return") == 1 and f.get(SHIPPING_PACKAGE_CODE_FIELD) == "PKG-RTO-001"
+		]
+		self.assertTrue(dedupe_filters, "no de-dupe lookup was made for an existing credit note")
+		for filters in dedupe_filters:
+			self.assertNotIn("docstatus", filters)
+
+		create_cn.assert_not_called()
+
+	def test_skips_when_no_invoice_found(self):
+		"""Log and skip the return when the original invoice doesn't exist."""
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch("frappe.db.get_value", return_value=None),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+		):
+			sync_rto_returns(self.so_data)
+
+		log.assert_called_once()
+		self.assertEqual(log.call_args.kwargs["status"], "Invalid")
+		create_cn.assert_not_called()
+
+	def test_filters_non_rto_returns(self):
+		"""Only "Courier Returned" is an RTO; other return types are left alone."""
+		so_data = {
+			"code": "SO-MIXED-001",
+			"returns": [
+				{"code": "RET-001", "type": "Customer Returned"},
+				{"code": "RET-002", "type": "Some Other Type"},
+				{"code": "PKG-RTO", "type": "Courier Returned"},
+			],
+		}
+
+		checked_packages = []
+
+		def mock_exists(doctype, filters=None, *args, **kwargs):
+			checked_packages.append(filters.get(SHIPPING_PACKAGE_CODE_FIELD))
+			return False
+
+		with (
+			patch("frappe.db.exists", side_effect=mock_exists),
+			patch("frappe.db.get_value", return_value=None),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log"),
+		):
+			sync_rto_returns(so_data)
+
+		self.assertEqual(checked_packages, ["PKG-RTO"])
+
+	def test_only_package_filters_to_one_return(self):
+		"""create_rto_return passes only_package so a sweep handles just that package."""
+		so_data = {
+			"code": "SO-MULTI-RTO",
+			"returns": [
+				{"code": "PKG-A", "type": "Courier Returned"},
+				{"code": "PKG-B", "type": "Courier Returned"},
+			],
+		}
+
+		checked_packages = []
+
+		def mock_exists(doctype, filters=None, *args, **kwargs):
+			checked_packages.append(filters.get(SHIPPING_PACKAGE_CODE_FIELD))
+			return False
+
+		with (
+			patch("frappe.db.exists", side_effect=mock_exists),
+			patch("frappe.db.get_value", return_value=None),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log"),
+		):
+			sync_rto_returns(so_data, only_package="PKG-B")
+
+		self.assertEqual(checked_packages, ["PKG-B"])
+
+	def test_continues_to_next_package_on_failure(self):
+		"""One failing package must not skip the rest, eg. a closed accounting period."""
+		so_data = {
+			"code": "SO-MULTI-RTO",
+			"returns": [
+				{"code": "PKG-A", "type": "Courier Returned", "created": 1625136326000},
+				{"code": "PKG-B", "type": "Courier Returned", "created": 1625136326000},
+			],
+		}
+
+		attempted = []
+
+		def mock_create_credit_note(invoice_name, posting_date=None):
+			attempted.append(invoice_name)
+			raise frappe.ValidationError("Accounting period is closed")
+
+		# Create mock client to pass the client validation check
+		mock_client = MagicMock()
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(
+				"frappe.db.get_value",
+				return_value=frappe._dict(name="INV-001", posting_date="2026-04-01"),
+			),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note", side_effect=mock_create_credit_note),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+			patch(f"{CANCELLATION_MODULE}.get_return_date_from_package", return_value=(1625136326000, {})),
+		):
+			sync_rto_returns(so_data, client=mock_client)
+
+		# both attempted despite the first raising
+		self.assertEqual(len(attempted), 2)
+		self.assertEqual(log.call_count, 2)
+		self.assertEqual(log.call_args.kwargs["status"], "Error")
+
+
+class TestCustomerInitiatedReturnSync(TestCase):
+	"""Test customer-initiated return credit note creation."""
+
+	def setUp(self):
+		super().setUp()
+		self.so_data = self.load_fixture("order-with-customer-return")
+
+	def test_skips_when_credit_note_already_exists(self):
+		"""De-duplication: skip if a credit note with this return code exists."""
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(self.so_data)
+
+		create_cn.assert_not_called()
+
+	def test_creates_credit_note_when_none_exists(self):
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(self.so_data)
+
+		create_cn.assert_called_once()
+		self.assertEqual(create_cn.call_args.args[1]["code"], "RET-CIR-001")
+
+	def test_returns_early_for_empty_returns(self):
+		"""No-op when the order has no returns."""
+		with patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn:
+			sync_customer_initiated_returns({"code": "SO-NO-RETURNS", "returns": []})
+
+		create_cn.assert_not_called()
+
+	def test_filters_non_customer_returns(self):
+		"""Only "Customer Returned" is handled here; RTO is a separate path."""
+		so_data = {
+			"code": "SO-MIXED-001",
+			"returns": [
+				{"code": "RET-001", "type": "Courier Returned"},
+				{"code": "RET-002", "type": "Customer Returned"},
+			],
+		}
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(so_data)
+
+		create_cn.assert_called_once()
+		self.assertEqual(create_cn.call_args.args[1]["code"], "RET-002")
+
+	def test_continues_to_next_return_on_failure(self):
+		"""One failing return must not skip the rest of the order's returns."""
+		so_data = {
+			"code": "SO-MULTI-CIR",
+			"returns": [
+				{"code": "RET-A", "type": "Customer Returned"},
+				{"code": "RET-B", "type": "Customer Returned"},
+			],
+		}
+
+		attempted = []
+
+		def mock_create(so_data, return_data, client=None):
+			attempted.append(return_data["code"])
+			raise frappe.ValidationError("Accounting period is closed")
+
+		# Create mock client to pass to the sync function
+		mock_client = MagicMock()
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note", side_effect=mock_create),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+		):
+			sync_customer_initiated_returns(so_data, client=mock_client)
+
+		self.assertEqual(attempted, ["RET-A", "RET-B"])
+		self.assertEqual(log.call_count, 2)
+		self.assertEqual(log.call_args.kwargs["status"], "Error")
+
+
+class TestInvoiceForReturnSelection(TestCase):
+	"""Test _get_invoice_for_return finds the right invoice for multi-package orders."""
+
+	@staticmethod
+	def _mock_get_all(invoices, invoice_item_map):
+		"""Stub frappe.get_all for the two queries _get_invoice_for_return makes."""
+
+		def mock_get_all(doctype, **kwargs):
+			if doctype == "Sales Invoice":
+				return invoices
+			if doctype == "Sales Invoice Item":
+				parents = kwargs["filters"]["parent"][1]
+				return [item for parent in parents for item in invoice_item_map.get(parent, [])]
+			return []
+
+		return mock_get_all
+
+	def test_returns_none_when_no_invoices(self):
+		with patch("frappe.get_all", return_value=[]):
+			self.assertIsNone(_get_invoice_for_return("SO-NO-INV", {"A"}))
+
+	def test_returns_single_invoice_without_checking_items(self):
+		"""With one invoice there's nothing to choose between, so skip the item query."""
+		with patch("frappe.get_all", return_value=["INV-001"]) as get_all:
+			self.assertEqual(_get_invoice_for_return("SO-001", {"A"}), "INV-001")
+
+		self.assertEqual(get_all.call_count, 1)
+
+	def test_finds_invoice_containing_returned_items(self):
+		invoices = ["INV-001", "INV-002", "INV-003"]
+		invoice_item_map = {
+			"INV-001": [{"parent": "INV-001", "so_detail": "A"}, {"parent": "INV-001", "so_detail": "B"}],
+			"INV-002": [{"parent": "INV-002", "so_detail": "C"}, {"parent": "INV-002", "so_detail": "D"}],
+			"INV-003": [{"parent": "INV-003", "so_detail": "E"}, {"parent": "INV-003", "so_detail": "F"}],
+		}
+
+		with patch("frappe.get_all", side_effect=self._mock_get_all(invoices, invoice_item_map)):
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"A", "B"}), "INV-001")
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"C", "D"}), "INV-002")
+			# a subset of one invoice's rows still resolves to that invoice
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"E"}), "INV-003")
+
+	def test_returns_none_when_items_spread_across_invoices(self):
+		"""No single invoice covers the return, so there's nothing safe to return against."""
+		invoices = ["INV-001", "INV-002"]
+		invoice_item_map = {
+			"INV-001": [{"parent": "INV-001", "so_detail": "A"}],
+			"INV-002": [{"parent": "INV-002", "so_detail": "B"}],
+		}
+
+		with patch("frappe.get_all", side_effect=self._mock_get_all(invoices, invoice_item_map)):
+			self.assertIsNone(_get_invoice_for_return("SO-MULTI", {"A", "B"}))
+
+	def test_returns_none_for_empty_returned_items(self):
+		"""An empty set is a subset of everything, so it must not match any invoice."""
+		invoices = ["INV-001", "INV-002"]
+		invoice_item_map = {
+			"INV-001": [{"parent": "INV-001", "so_detail": "A"}],
+			"INV-002": [{"parent": "INV-002", "so_detail": "B"}],
+		}
+
+		with patch("frappe.get_all", side_effect=self._mock_get_all(invoices, invoice_item_map)):
+			self.assertIsNone(_get_invoice_for_return("SO-MULTI", set()))
+
+
+class TestPartialReturns(TestCase):
+	"""Test _handle_partial_returns strips items and rescales tax.
+
+	Doubles are SimpleNamespace, not frappe._dict: on a _dict `.items` resolves to
+	the built-in dict method, and hasattr() is always True.
+	"""
+
+	@staticmethod
+	def _credit_note(items, item_wise_tax_detail=None, tax_amount=100.0):
+		tax = SimpleNamespace(tax_amount=tax_amount)
+		if item_wise_tax_detail is not None:
+			tax.item_wise_tax_detail = json.dumps(item_wise_tax_detail)
+
+		return SimpleNamespace(
+			items=[SimpleNamespace(**item) for item in items],
+			taxes=[tax],
+		)
+
+	def test_strips_non_returned_items_and_rescales_tax(self):
+		credit_note = self._credit_note(
+			items=[
+				{"item_code": "ITEM-A", "qty": 2.0, "sales_invoice_item": "SI-A"},
+				{"item_code": "ITEM-B", "qty": 2.0, "sales_invoice_item": "SI-B"},
+			],
+			item_wise_tax_detail={"ITEM-A": [18.0, 36.0], "ITEM-B": [18.0, 36.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		self.assertEqual([item.item_code for item in credit_note.items], ["ITEM-A"])
+		# ITEM-A fully returned keeps its tax, ITEM-B is zeroed
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 36.0)
+
+	def test_scales_tax_by_returned_quantity(self):
+		"""Returning half the qty of an item credits half its tax."""
+		credit_note = self._credit_note(
+			items=[
+				{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A1"},
+				{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A2"},
+			],
+			item_wise_tax_detail={"ITEM-A": [18.0, 36.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A1"])
+
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 18.0)
+
+	def test_survives_tax_detail_naming_an_absent_item(self):
+		"""The breakup can name an item that isn't on the credit note."""
+		credit_note = self._credit_note(
+			items=[{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A"}],
+			item_wise_tax_detail={"ITEM-A": [18.0, 18.0], "ITEM-GHOST": [18.0, 18.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		# only the item on the document contributes tax
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 18.0)
+
+	def test_skips_tax_rows_without_item_wise_detail(self):
+		"""Tax rows without an item wise breakup are left alone."""
+		credit_note = self._credit_note(
+			items=[{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A"}],
+			item_wise_tax_detail=None,
+			tax_amount=50.0,
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		self.assertEqual(credit_note.taxes[0].tax_amount, 50.0)
+
+
+class TestSyncOldReturns(TestCase):
+	"""Test _sync_old_returns orchestrates both return types."""
+
+	def test_calls_both_sync_functions(self):
+		from ecommerce_integrations.unicommerce.sync_old_orders import _sync_old_returns
+
+		detail = {"code": "SO-OLD-001", "returns": []}
+
+		with (
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.sync_customer_initiated_returns") as sync_cir,
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.sync_rto_returns") as sync_rto,
+		):
+			_sync_old_returns(detail, "SO-OLD-001")
+
+		sync_cir.assert_called_once_with(detail, client=None)
+		sync_rto.assert_called_once_with(detail, client=None)
+
+	def test_continues_on_customer_return_failure(self):
+		"""RTO sync still runs when the customer return sync raises."""
+		from ecommerce_integrations.unicommerce.sync_old_orders import _sync_old_returns
+
+		detail = {"code": "SO-OLD-002", "returns": []}
+
+		with (
+			patch(
+				f"{SYNC_OLD_ORDERS_MODULE}.sync_customer_initiated_returns",
+				side_effect=ValueError("Customer return sync failed"),
+			),
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.sync_rto_returns") as sync_rto,
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.create_unicommerce_log") as log,
+		):
+			_sync_old_returns(detail, "SO-OLD-002")
+
+		sync_rto.assert_called_once()
+		log.assert_called_once()
+		self.assertEqual(log.call_args.kwargs["status"], "Error")
+
+	def test_continues_on_rto_failure(self):
+		"""Customer return sync still runs when the RTO sync raises."""
+		from ecommerce_integrations.unicommerce.sync_old_orders import _sync_old_returns
+
+		detail = {"code": "SO-OLD-003", "returns": []}
+
+		with (
+			patch(
+				f"{SYNC_OLD_ORDERS_MODULE}.sync_rto_returns",
+				side_effect=ValueError("RTO sync failed"),
+			),
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.sync_customer_initiated_returns") as sync_cir,
+			patch(f"{SYNC_OLD_ORDERS_MODULE}.create_unicommerce_log") as log,
+		):
+			_sync_old_returns(detail, "SO-OLD-003")
+
+		sync_cir.assert_called_once()
+		log.assert_called_once()
+		self.assertEqual(log.call_args.kwargs["status"], "Error")


### PR DESCRIPTION
Ticket Ref: [#74405](https://support.frappe.io/helpdesk/tickets/74405?view=VIEW-HD+Ticket-1533)

## Description

Fixes credit note creation for RTO and customer initiated returns with proper invoice selection and error handling.

## Issues

1. **Wrong invoice selected:** Credit notes could select another credit note instead of the original invoice.
2. **Multi package returns fail:** Multiple packages could create empty credit notes.
3. **No error isolation:** One failed return could stop other returns.
4. **Old returns not synced:** Historical returns could miss credit notes.
5. **Division by zero:** Partial returns crash when tax breakup references items not on the credit note.
6. **v17 compatibility:** `for_update` was removed in v17.

## Fixes

1. **Invoice selection:** Added `is_return: 0` and `docstatus: 1` filters.
2. **Multi package matching:** Added `_get_invoice_for_return` to match the correct invoice.
3. **Error isolation:** Added `try/except` for individual returns.
4. **Old return sync:** Added `_sync_old_returns` after invoicing.
5. **Partial return guard:** Added `original_qty` check before division.
6. **v17 compatibility:** Removed `for_update=True`.
