### PR TITLE
fix(shopify): mark fully discounted order lines as free items (backport #460)

### DIFF
--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -151,11 +151,15 @@ def get_order_items(order_items, setting, delivery_date, taxes_inclusive):
 
 		if all_product_exists:
 			item_code = get_item_code(shopify_item)
+			rate = _get_item_price(shopify_item, taxes_inclusive)
 			items.append(
 				{
 					"item_code": item_code,
 					"item_name": shopify_item.get("name"),
-					"rate": _get_item_price(shopify_item, taxes_inclusive),
+					"rate": rate,
+					# a fully discounted line nets to 0; flag it free so ERPNext keeps
+					# the rate at 0 instead of back-filling it from the price list
+					"is_free_item": 1 if flt(rate) <= 0 else 0,
 					"delivery_date": delivery_date,
 					"qty": shopify_item.get("quantity"),
 					"stock_uom": shopify_item.get("uom") or "Nos",

--- a/ecommerce_integrations/shopify/tests/test_order.py
+++ b/ecommerce_integrations/shopify/tests/test_order.py
@@ -1,13 +1,44 @@
 # Copyright (c) 2021, Frappe and Contributors
 # See LICENSE
 
-import json
+from unittest.mock import patch
 
+import frappe
 from frappe.tests import IntegrationTestCase
 
-from ecommerce_integrations.shopify.order import sync_sales_order
+from ecommerce_integrations.shopify.order import get_order_items
 
 
 class TestOrder(IntegrationTestCase):
 	def test_sync_with_variants(self):
 		pass
+
+	@patch("ecommerce_integrations.shopify.order.get_item_code", return_value="_Test Item")
+	def test_fully_discounted_line_is_marked_free(self, _):
+		# 100% discount code allocated across the line -> nets to 0
+		line_items = [
+			{
+				"name": "Free Tea",
+				"quantity": 2,
+				"price": "13.95",
+				"product_exists": True,
+				"discount_allocations": [{"amount": "27.90"}],
+			},
+			# partially discounted line must stay a normal, priced row
+			{
+				"name": "Discounted Tea",
+				"quantity": 1,
+				"price": "10.00",
+				"product_exists": True,
+				"discount_allocations": [{"amount": "1.00"}],
+			},
+		]
+
+		items = get_order_items(
+			line_items, frappe._dict(warehouse="_Test Warehouse"), delivery_date=None, taxes_inclusive=False
+		)
+
+		self.assertEqual(items[0]["rate"], 0)
+		self.assertEqual(items[0]["is_free_item"], 1)
+		self.assertEqual(items[1]["rate"], 9.0)
+		self.assertEqual(items[1]["is_free_item"], 0)


### PR DESCRIPTION
Backport of #460 to `version-16`.

https://support.frappe.io/helpdesk/tickets/76090?view=VIEW-HD+Ticket-70177