### PR TITLE
fix/unicommerce old order returns sync

### DIFF
--- a/ecommerce_integrations/unicommerce/cancellation_and_returns.py
+++ b/ecommerce_integrations/unicommerce/cancellation_and_returns.py
@@ -132,12 +132,10 @@ def create_rto_return(package_info, client: UnicommerceAPIClient):
 		return
 
 	# the sweep calls us once per package that changed state
-	sync_rto_returns(
-		so_data, only_package=package_code, client=client, facility_code=invoice.get(FACILITY_CODE_FIELD)
-	)
+	sync_rto_returns(so_data, only_package=package_code, client=client)
 
 
-def sync_rto_returns(so_data, only_package=None, client=None, facility_code=None):
+def sync_rto_returns(so_data, only_package=None, client=None):
 	"""Create credit notes for RTO packages in the order payload.
 
 	Payload driven, so it also covers old orders outside the hourly sweep's window.
@@ -160,7 +158,7 @@ def sync_rto_returns(so_data, only_package=None, client=None, facility_code=None
 		invoice = frappe.db.get_value(
 			"Sales Invoice",
 			{SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 0, "docstatus": 1},
-			["name", "posting_date"],
+			["name", "posting_date", FACILITY_CODE_FIELD],
 			as_dict=True,
 		)
 		if not invoice:
@@ -181,8 +179,17 @@ def sync_rto_returns(so_data, only_package=None, client=None, facility_code=None
 				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
 			)
 			continue
+		# Use facility code from invoice (each package can have different facility)
+		package_facility_code = invoice.get(FACILITY_CODE_FIELD)
+		if not package_facility_code:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Facility code not found on invoice {invoice.get('name')} for package {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
 		return_timestamp, return_details = get_return_date_from_package(
-			client, shipment_code=package_code, facility_code=facility_code
+			client, shipment_code=package_code, facility_code=package_facility_code
 		)
 
 		# Use return API date - no fallback to invoice date
@@ -386,9 +393,13 @@ def create_cir_credit_note(so_data, return_data, client=None):
 
 	facility_code = si.get(FACILITY_CODE_FIELD)
 
-	# Initialize client if not provided
 	if not client:
-		client = UnicommerceAPIClient()
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"Client not provided for return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
 
 	return_timestamp, return_details = get_return_date_from_package(
 		client, return_code=return_data["code"], facility_code=facility_code

--- a/ecommerce_integrations/unicommerce/tests/test_returns.py
+++ b/ecommerce_integrations/unicommerce/tests/test_returns.py
@@ -13,6 +13,7 @@ from ecommerce_integrations.unicommerce.cancellation_and_returns import (
 	sync_rto_returns,
 )
 from ecommerce_integrations.unicommerce.constants import (
+	FACILITY_CODE_FIELD,
 	SHIPPING_PACKAGE_CODE_FIELD,
 )
 from ecommerce_integrations.unicommerce.tests.utils import TestCase
@@ -156,7 +157,11 @@ class TestRTOReturnSync(TestCase):
 			patch("frappe.db.exists", return_value=False),
 			patch(
 				"frappe.db.get_value",
-				return_value=frappe._dict(name="INV-001", posting_date="2026-04-01"),
+				return_value=frappe._dict(
+					name="INV-001",
+					posting_date="2026-04-01",
+					**{FACILITY_CODE_FIELD: "FAC-001"},
+				),
 			),
 			patch(f"{CANCELLATION_MODULE}.create_credit_note", side_effect=mock_create_credit_note),
 			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
@@ -179,28 +184,31 @@ class TestCustomerInitiatedReturnSync(TestCase):
 
 	def test_skips_when_credit_note_already_exists(self):
 		"""De-duplication: skip if a credit note with this return code exists."""
+		mock_client = MagicMock()
 		with (
 			patch("frappe.db.exists", return_value=True),
 			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
 		):
-			sync_customer_initiated_returns(self.so_data)
+			sync_customer_initiated_returns(self.so_data, client=mock_client)
 
 		create_cn.assert_not_called()
 
 	def test_creates_credit_note_when_none_exists(self):
+		mock_client = MagicMock()
 		with (
 			patch("frappe.db.exists", return_value=False),
 			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
 		):
-			sync_customer_initiated_returns(self.so_data)
+			sync_customer_initiated_returns(self.so_data, client=mock_client)
 
 		create_cn.assert_called_once()
 		self.assertEqual(create_cn.call_args.args[1]["code"], "RET-CIR-001")
 
 	def test_returns_early_for_empty_returns(self):
 		"""No-op when the order has no returns."""
+		mock_client = MagicMock()
 		with patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn:
-			sync_customer_initiated_returns({"code": "SO-NO-RETURNS", "returns": []})
+			sync_customer_initiated_returns({"code": "SO-NO-RETURNS", "returns": []}, client=mock_client)
 
 		create_cn.assert_not_called()
 
@@ -214,11 +222,12 @@ class TestCustomerInitiatedReturnSync(TestCase):
 			],
 		}
 
+		mock_client = MagicMock()
 		with (
 			patch("frappe.db.exists", return_value=False),
 			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
 		):
-			sync_customer_initiated_returns(so_data)
+			sync_customer_initiated_returns(so_data, client=mock_client)
 
 		create_cn.assert_called_once()
 		self.assertEqual(create_cn.call_args.args[1]["code"], "RET-002")


### PR DESCRIPTION
## Description

Fixes facility code handling and client validation in return credit note creation.

## Issues

* **Facility code passed as parameter instead of from invoice**
* **Client created dynamically instead of validated**
* **Tests call functions without client parameter**

## Fixes

* **Get facility code from invoice instead of parameter**
* **Add client validation and fail safely**
* **Update tests to pass mock clients**