### PR TITLE
feat/unicommerce credit note backfill v15

### DIFF
--- a/ecommerce_integrations/unicommerce/api_client.py
+++ b/ecommerce_integrations/unicommerce/api_client.py
@@ -450,6 +450,53 @@ class UnicommerceAPIClient:
 
 		if statuses and "elements" in search_results:
 			return search_results["elements"]
+		else:
+			frappe.log_error("Failed to search shipping packages:", search_results)
+			return []
+
+	def get_return_details(
+		self,
+		reverse_pickup_code: str | None = None,
+		shipment_code: str | None = None,
+		facility_code: str | None = None,
+	) -> dict[str, Any] | None:
+		"""Get return details using reverse pickup code or shipping package code.
+
+		Provides accurate return creation date via returnSaleOrderValue.returnCreatedDate.
+		Requires Facility header for authentication.
+
+		Args:
+		        reverse_pickup_code: Reverse pickup code for CIR returns
+		        shipment_code: Shipping package code for RTO returns
+		        facility_code: Facility code (required for Return API header)
+
+		Returns:
+		        Return details including returnSaleOrderValue with returnCreatedDate,
+		        or None if API call fails
+
+		ref: https://documentation.unicommerce.com/docs/return-get.html
+		"""
+		body = {}
+
+		# Only include the parameter we're actually using (not null)
+		if reverse_pickup_code:
+			body["reversePickupCode"] = reverse_pickup_code
+		if shipment_code:
+			body["shipmentCode"] = shipment_code
+
+		# Facility header is required for Return API
+		extra_headers = {}
+		if facility_code:
+			extra_headers["Facility"] = facility_code
+
+		response, status = self.request(
+			endpoint="/services/rest/v1/oms/return/get",
+			body=body,
+			headers=extra_headers,
+		)
+
+		if status:
+			return response
 
 	def create_import_job(
 		self,

--- a/ecommerce_integrations/unicommerce/cancellation_and_returns.py
+++ b/ecommerce_integrations/unicommerce/cancellation_and_returns.py
@@ -20,6 +20,7 @@ from ecommerce_integrations.unicommerce.constants import (
 	SHIPPING_PROVIDER_CODE,
 	TRACKING_CODE_FIELD,
 )
+from ecommerce_integrations.unicommerce.utils import create_unicommerce_log, get_unicommerce_date
 
 
 def fully_cancel_orders(unicommerce_order_codes: list[str]) -> None:
@@ -109,34 +110,128 @@ def _serialize_items(trans_items) -> str:
 
 
 def create_rto_return(package_info, client: UnicommerceAPIClient):
-	"""When RTO is expected create a credit note in draft state with required details.
-
-	RTO => Return To Origin. Entire package is being returned.
-	"""
+	"""Create a credit note when RTO is expected (Return To Origin)."""
 
 	package_code = package_info["code"]
 
+	# is_return=0, else this can pick the credit note instead of the invoice
 	invoice = frappe.db.get_value(
 		"Sales Invoice",
-		{SHIPPING_PACKAGE_CODE_FIELD: package_code},
-		["name", ORDER_CODE_FIELD, CHANNEL_ID_FIELD],
+		{SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 0},
+		["name", ORDER_CODE_FIELD, CHANNEL_ID_FIELD, FACILITY_CODE_FIELD],
 		as_dict=True,
 	)
 
-	already_returned = frappe.db.get_value(
+	if not invoice:
+		return
+
+	already_returned = frappe.db.exists(
 		"Sales Invoice", {SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 1}
 	)
-	if not invoice or already_returned:
+	if already_returned:
 		return
 
 	so_data = client.get_sales_order(invoice.get(ORDER_CODE_FIELD))
+	if not so_data:
+		return
 
+	# the sweep calls us once per package that changed state
+	sync_rto_returns(so_data, only_package=package_code, client=client)
+
+
+def sync_rto_returns(so_data, only_package=None, client=None):
+	"""Create credit notes for RTO packages in the order payload.
+
+	Payload driven, so it also covers old orders outside the hourly sweep's window.
+	An RTO return `code` is the shipping package code, which links to the invoice.
+	"""
 	rto_returns = [
-		r for r in so_data["returns"] if r["type"] == "Courier Returned" and r["code"] == package_code
+		r
+		for r in so_data.get("returns", [])
+		if r["type"] == "Courier Returned" and (not only_package or r["code"] == only_package)
 	]
-	if rto_returns:
-		credit_note = create_credit_note(invoice.name)
-		credit_note.save()
+
+	for rto_return in rto_returns:
+		package_code = rto_return["code"]
+
+		# no docstatus filter: credit notes are left in draft, so submitted never matches
+		if frappe.db.exists("Sales Invoice", {SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 1}):
+			continue
+
+		# returns can only be made against a submitted invoice, never a credit note
+		invoice = frappe.db.get_value(
+			"Sales Invoice",
+			{SHIPPING_PACKAGE_CODE_FIELD: package_code, "is_return": 0, "docstatus": 1},
+			["name", "posting_date", FACILITY_CODE_FIELD],
+			as_dict=True,
+		)
+		if not invoice:
+			create_unicommerce_log(
+				status="Invalid",
+				message=(
+					f"No submitted sales invoice found for shipping package {package_code}, "
+					f"skipped RTO return on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+
+		# Get return creation date and full Return API response (RTO uses shipment code)
+		if not client:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Client not provided for RTO return {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+
+		# Use facility code from invoice (each package can have different facility)
+		package_facility_code = invoice.get(FACILITY_CODE_FIELD)
+		if not package_facility_code:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Facility code not found on invoice {invoice.get('name')} for package {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+			continue
+
+		return_timestamp, return_details = get_return_date_from_package(
+			client, shipment_code=package_code, facility_code=package_facility_code
+		)
+
+		# Use return API date - fallback to invoice date if API fails
+		posting_date = None
+		if return_timestamp:
+			posting_date = get_unicommerce_date(return_timestamp)
+		else:
+			create_unicommerce_log(
+				status="Invalid",
+				message=f"Unable to get return date from Return API for {package_code}",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
+
+		# isolated so a failure (eg. closed period) doesn't skip the remaining packages
+		try:
+			credit_note = create_credit_note(invoice.name, posting_date=posting_date)
+			credit_note.save()
+
+			create_unicommerce_log(
+				status="Success",
+				message="RTO credit note created successfully",
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+				request_data=return_details,
+			)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=(
+					f"Failed to create RTO credit note for shipping package {package_code} "
+					f"on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_rto_returns",
+			)
 
 
 def get_return_warehouse(facility_code):
@@ -145,10 +240,53 @@ def get_return_warehouse(facility_code):
 	)
 
 
-def create_credit_note(invoice_name):
+def get_return_date_from_package(client, return_code=None, facility_code=None, shipment_code=None):
+	"""Get accurate return timestamp from Unicommerce Return API.
+
+	Uses the Get Return API to fetch returnSaleOrderValue.returnCreatedDate
+	which represents when the return was actually created.
+
+	Args:
+	        client: UnicommerceAPIClient instance
+	        return_code: Reverse pickup code for CIR returns
+	        facility_code: Facility code for Return API header (required)
+	        shipment_code: Shipping package code for RTO returns
+
+	Returns:
+	        tuple: (timestamp in milliseconds, return_details) or (None, None)
+	"""
+	try:
+		return_details = client.get_return_details(
+			reverse_pickup_code=return_code,
+			shipment_code=shipment_code,
+			facility_code=facility_code,
+		)
+
+		if return_details and return_details.get("returnSaleOrderValue"):
+			# Return API gives datetime string, need to convert to timestamp
+			return_created_str = return_details["returnSaleOrderValue"].get("returnCreatedDate")
+			if return_created_str:
+				# Convert datetime string to timestamp (milliseconds)
+				dt = datetime.strptime(return_created_str, "%Y-%m-%d %H:%M:%S")
+				timestamp = int(dt.timestamp() * 1000)
+				return timestamp, return_details
+
+	except Exception as e:
+		code = return_code or shipment_code
+		frappe.log_error(f"Failed to fetch return details for {code}: {e}")
+
+	return None, None
+
+
+def create_credit_note(invoice_name, posting_date=None):
 	credit_note = make_sales_return(invoice_name)
 	facility_code = credit_note.get(FACILITY_CODE_FIELD)
 	return_warehouse = get_return_warehouse(facility_code)
+
+	# Set posting date for backfilled returns so they land in the correct period
+	if posting_date:
+		credit_note.set_posting_time = 1
+		credit_note.posting_date = posting_date
 
 	for item in credit_note.items:
 		item.warehouse = return_warehouse or item.warehouse
@@ -163,7 +301,7 @@ def create_credit_note(invoice_name):
 
 
 def check_and_update_customer_initiated_returns(orders, client: UnicommerceAPIClient) -> None:
-	"""Create credit note if order contains customer intiated returns."""
+	"""Create credit notes for customer-initiated returns on recently updated orders."""
 
 	recently_changed_orders = _filter_recent_orders(orders)
 
@@ -171,47 +309,145 @@ def check_and_update_customer_initiated_returns(orders, client: UnicommerceAPICl
 		so_data = client.get_sales_order(order["code"])
 		if not so_data:
 			continue
-		sync_customer_initiated_returns(so_data)
+		sync_customer_initiated_returns(so_data, client)
 
 
-def sync_customer_initiated_returns(so_data):
+def sync_customer_initiated_returns(so_data, client=None):
 	customer_returns = [r for r in so_data.get("returns", []) if r["type"] == "Customer Returned"]
 	if not customer_returns:
 		return
 
 	for customer_return in customer_returns:
-		if not frappe.db.exists("Sales Invoice", {RETURN_CODE_FIELD: customer_return["code"]}):
-			create_cir_credit_note(so_data, customer_return)
+		if frappe.db.exists("Sales Invoice", {RETURN_CODE_FIELD: customer_return["code"]}):
+			continue
+
+		# isolated so a failure (eg. closed period) doesn't skip the remaining returns
+		try:
+			create_cir_credit_note(so_data, customer_return, client)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=(
+					f"Failed to create credit note for return {customer_return['code']} "
+					f"on order {so_data['code']}"
+				),
+				method="ecommerce_integrations.unicommerce.cancellation_and_returns.sync_customer_initiated_returns",
+			)
 
 
-def create_cir_credit_note(so_data, return_data):
+def _get_invoice_for_return(order_code, returned_so_items):
+	"""Find the invoice containing the returned items.
+
+	An order with multiple packages has multiple invoices. Picking the wrong one
+	leaves an empty credit note after _handle_partial_returns strips items.
+	"""
+	invoices = frappe.get_all(
+		"Sales Invoice",
+		filters={ORDER_CODE_FIELD: order_code, "is_return": 0, "docstatus": 1},
+		pluck="name",
+	)
+	if len(invoices) <= 1:
+		return invoices[0] if invoices else None
+
+	# single query for all invoices, else one per invoice
+	all_si_items = frappe.get_all(
+		"Sales Invoice Item",
+		filters={"parent": ["in", invoices]},
+		fields=["parent", "so_detail"],
+	)
+
+	invoice_items = {}
+	for item in all_si_items:
+		invoice_items.setdefault(item["parent"], set()).add(item["so_detail"])
+
+	for invoice_name in invoices:
+		si_so_details = invoice_items.get(invoice_name, set())
+		if returned_so_items and returned_so_items <= si_so_details:
+			return invoice_name
+
+
+def create_cir_credit_note(so_data, return_data, client=None):
 	sales_order_name = frappe.db.get_value("Sales Order", {ORDER_CODE_FIELD: so_data["code"]})
+	if not sales_order_name:
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"No sales order found for {so_data['code']}, skipped return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
 	so = frappe.get_doc("Sales Order", sales_order_name)
 
 	# Get items from SO which are returned, map SO item -> SI item with linked rows.
 	so_item_code_map = {item.get(ORDER_ITEM_CODE_FIELD): item.name for item in so.items}
 
-	invoice_name = frappe.db.get_value("Sales Invoice", {ORDER_CODE_FIELD: so_data["code"], "is_return": 0})
+	returned_so_codes = [item.get("saleOrderItemCode") for item in return_data.get("returnItems") or []]
+	returned_so_items = {so_item_code_map.get(code) for code in returned_so_codes} - {None}
+
+	invoice_name = _get_invoice_for_return(so_data["code"], returned_so_items)
+	if not invoice_name:
+		# no invoice, or the returned rows span more than one package's invoice
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"No sales invoice found for order {so_data['code']}, skipped return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
 	si = frappe.get_doc("Sales Invoice", invoice_name)
 	so_si_item_map = {item.so_detail: item.name for item in si.items}
 
-	credit_note = create_credit_note(si.name)
+	facility_code = si.get(FACILITY_CODE_FIELD)
 
+	if not client:
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"Client not provided for return {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+		return
+
+	return_timestamp, return_details = get_return_date_from_package(
+		client, return_code=return_data["code"], facility_code=facility_code
+	)
+
+	# Use shipping package return date
+	posting_date = None
+	if return_timestamp:
+		posting_date = get_unicommerce_date(return_timestamp)
+	else:
+		create_unicommerce_log(
+			status="Invalid",
+			message=f"Unable to get return date from Return API for {return_data['code']}",
+			method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		)
+
+	credit_note = create_credit_note(si.name, posting_date=posting_date)
+
+	# return code is what the dedupe check looks up, else every run adds a draft
+	credit_note.set(RETURN_CODE_FIELD, return_data["code"])
 	credit_note.set(TRACKING_CODE_FIELD, return_data.get("trackingNumber"))
 	credit_note.set(SHIPPING_PROVIDER_CODE, return_data.get("shippingProvider"))
 
-	returned_so_codes = [item.get("saleOrderItemCode") for item in return_data.get("returnItems")]
-	returned_si_items = [so_si_item_map.get(so_item_code_map.get(code)) for code in returned_so_codes]
+	returned_si_items = [so_si_item_map.get(so_item) for so_item in returned_so_items]
 
 	if set(returned_si_items) != set(so_si_item_map.values()):
 		_handle_partial_returns(credit_note, returned_si_items)
-		pass
 
 	credit_note.save()
 
+	create_unicommerce_log(
+		status="Success",
+		message="Customer return credit note created successfully",
+		method="ecommerce_integrations.unicommerce.cancellation_and_returns.create_cir_credit_note",
+		request_data=return_details,
+	)
+
+	return credit_note
+
 
 def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
-	"""Remove non-returned item from credit note and update taxes"""
+	"""Remove non-returned items from credit note and update taxes."""
 
 	item_code_to_qty_map = defaultdict(float)
 	for item in credit_note.items:
@@ -226,6 +462,9 @@ def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
 
 	for tax in credit_note.taxes:
 		# reduce total value
+		if not hasattr(tax, "item_wise_tax_detail") or not tax.item_wise_tax_detail:
+			continue
+
 		item_wise_tax_detail = json.loads(tax.item_wise_tax_detail)
 		new_tax_amt = 0.0
 
@@ -234,7 +473,14 @@ def _handle_partial_returns(credit_note, returned_items: list[str]) -> None:
 			if not tax_distribution[1]:
 				# Ignore 0 values
 				continue
-			return_percent = returned_qty_map.get(item_code, 0.0) / item_code_to_qty_map.get(item_code)
+
+			# the breakup can name an item that isn't on this credit note
+			original_qty = item_code_to_qty_map.get(item_code) or 0.0
+			if not original_qty:
+				tax_distribution[1] = 0.0
+				continue
+
+			return_percent = returned_qty_map.get(item_code, 0.0) / original_qty
 			tax_distribution[1] *= return_percent
 			new_tax_amt += tax_distribution[1]
 

--- a/ecommerce_integrations/unicommerce/sync_old_orders.py
+++ b/ecommerce_integrations/unicommerce/sync_old_orders.py
@@ -3,6 +3,10 @@ from frappe import _
 from frappe.utils import add_days, getdate
 
 from ecommerce_integrations.unicommerce.api_client import UnicommerceAPIClient, _utc_timeformat
+from ecommerce_integrations.unicommerce.cancellation_and_returns import (
+	sync_customer_initiated_returns,
+	sync_rto_returns,
+)
 from ecommerce_integrations.unicommerce.constants import ORDER_CODE_FIELD, SETTINGS_DOCTYPE
 from ecommerce_integrations.unicommerce.order import _create_sales_invoices, create_order
 from ecommerce_integrations.unicommerce.utils import create_unicommerce_log
@@ -132,6 +136,8 @@ def _run_sync(settings, from_date, to_date, client=None):
 
 				if completed_mode:
 					_create_sales_invoices(detail, sales_order, client)
+					# after invoicing: the credit note is built from the invoice
+					_sync_old_returns(detail, code, client)
 
 				# Count only after the order (and its invoice) is fully handled, so a
 				# late failure lands in `failed` instead of double-counting this order.
@@ -145,6 +151,29 @@ def _run_sync(settings, from_date, to_date, client=None):
 
 	_log_summary(summary)
 	return summary
+
+
+def _sync_old_returns(detail, order_code, client=None):
+	"""Create credit notes for returns on an old order.
+
+	The hourly sweeps only see recently updated records, so old returns are synced
+	here while the order payload is in hand. Each type is isolated so one failure
+	doesn't block the other, without rolling back the order just synced.
+	"""
+	sync_functions = (
+		("customer initiated", sync_customer_initiated_returns),
+		("RTO", sync_rto_returns),
+	)
+	for return_type, sync_returns in sync_functions:
+		try:
+			sync_returns(detail, client=client)
+		except Exception as e:
+			create_unicommerce_log(
+				status="Error",
+				exception=e,
+				make_new=True,
+				message=f"Failed to sync {return_type} returns for order {order_code}",
+			)
 
 
 def _fetch_orders_in_range(client, from_date, to_date, status, summary):

--- a/ecommerce_integrations/unicommerce/tests/fixtures/order-with-customer-return.json
+++ b/ecommerce_integrations/unicommerce/tests/fixtures/order-with-customer-return.json
@@ -1,0 +1,53 @@
+{
+  "code": "SO-CIR-001",
+  "displayOrderCode": "DO-CIR-001",
+  "channel": "RAINFOREST",
+  "facility": {
+    "code": "Test-123"
+  },
+  "state": "COMPLETE",
+  "statusCode": "COMPLETE",
+  "creationTime": 1627896326000,
+  "modifiedTime": 1627982726000,
+  "saleOrderItems": [
+    {
+      "code": "SOI-CIR-001",
+      "saleOrderItemCode": "SOI-CIR-001",
+      "itemCode": "MC-100",
+      "channelItemId": "CH-ITEM-001",
+      "quantity": 2,
+      "statusCode": "CREATED"
+    },
+    {
+      "code": "SOI-CIR-002",
+      "saleOrderItemCode": "SOI-CIR-002",
+      "itemCode": "MC-100",
+      "channelItemId": "CH-ITEM-002",
+      "quantity": 1,
+      "statusCode": "CREATED"
+    }
+  ],
+  "returns": [
+    {
+      "code": "RET-CIR-001",
+      "type": "Customer Returned",
+      "statusCode": "COMPLETE",
+      "creationTime": 1627900000000,
+      "trackingNumber": "TRACK-CIR-001",
+      "shippingProvider": "Bluedart",
+      "returnItems": [
+        {
+          "saleOrderItemCode": "SOI-CIR-001",
+          "quantity": 1
+        }
+      ]
+    }
+  ],
+  "shippingPackages": [
+    {
+      "code": "PKG-CIR-001",
+      "statusCode": "SHIPPED",
+      "returnExpected": false
+    }
+  ]
+}

--- a/ecommerce_integrations/unicommerce/tests/fixtures/order-with-rto-return.json
+++ b/ecommerce_integrations/unicommerce/tests/fixtures/order-with-rto-return.json
@@ -1,0 +1,39 @@
+{
+  "code": "SO-RTO-001",
+  "displayOrderCode": "DO-RTO-001",
+  "channel": "RAINFOREST",
+  "facility": {
+    "code": "Test-123"
+  },
+  "state": "COMPLETE",
+  "statusCode": "COMPLETE",
+  "creationTime": 1627896326000,
+  "modifiedTime": 1627982726000,
+  "saleOrderItems": [
+    {
+      "code": "SOI-RTO-001",
+      "saleOrderItemCode": "SOI-RTO-001",
+      "itemCode": "MC-100",
+      "channelItemId": "CH-ITEM-001",
+      "quantity": 2,
+      "statusCode": "CREATED"
+    }
+  ],
+  "returns": [
+    {
+      "code": "PKG-RTO-001",
+      "type": "Courier Returned",
+      "statusCode": "COMPLETE",
+      "creationTime": 1627900000000,
+      "trackingNumber": "TRACK-RTO-001",
+      "shippingProvider": "DTDC"
+    }
+  ],
+  "shippingPackages": [
+    {
+      "code": "PKG-RTO-001",
+      "statusCode": "RETURNED",
+      "returnExpected": true
+    }
+  ]
+}

--- a/ecommerce_integrations/unicommerce/tests/test_returns.py
+++ b/ecommerce_integrations/unicommerce/tests/test_returns.py
@@ -1,0 +1,423 @@
+"""Tests for Unicommerce return and credit note functionality."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from ecommerce_integrations.unicommerce.cancellation_and_returns import (
+	_get_invoice_for_return,
+	_handle_partial_returns,
+	create_cir_credit_note,
+	create_credit_note,
+	create_rto_return,
+	get_return_date_from_package,
+	sync_customer_initiated_returns,
+	sync_rto_returns,
+)
+from ecommerce_integrations.unicommerce.constants import (
+	FACILITY_CODE_FIELD,
+	RETURN_CODE_FIELD,
+	SHIPPING_PACKAGE_CODE_FIELD,
+)
+from ecommerce_integrations.unicommerce.tests.utils import TestCase
+
+CANCELLATION_MODULE = "ecommerce_integrations.unicommerce.cancellation_and_returns"
+
+
+class TestRTOReturnSync(TestCase):
+	"""Test RTO return credit note creation."""
+
+	def setUp(self):
+		super().setUp()
+		self.so_data = self.load_fixture("order-with-rto-return")
+		self.client = MagicMock()
+
+	def test_skips_when_credit_note_already_exists(self):
+		"""De-duplication: skip if a credit note exists for the package."""
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+		):
+			sync_rto_returns(self.so_data, client=self.client)
+
+		create_cn.assert_not_called()
+
+	def test_creates_rto_credit_note_for_valid_return(self):
+		"""Create credit note when valid RTO return exists and no credit note yet."""
+		mock_invoice = {
+			"name": "INV-001",
+			"posting_date": "2024-08-01",
+			"unicommerce_facility_code": "Test-123",
+		}
+
+		def mock_db_get_value(*args, **kwargs):
+			"""Mock that returns invoice for any Sales Invoice get_value call."""
+
+			# Return mock_invoice as an object that supports attribute access
+			# Create a simple object that has both dict and attribute access
+			class InvoiceDict(dict):
+				def __getattr__(self, name):
+					return self[name]
+
+			return InvoiceDict(**mock_invoice)
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch("frappe.db.get_value", side_effect=mock_db_get_value),
+			patch(f"{CANCELLATION_MODULE}.get_return_date_from_package", return_value=(1627900000000, {})),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log"),
+		):
+			credit_note_mock = MagicMock()
+			credit_note_mock.save = MagicMock()
+			create_cn.return_value = credit_note_mock
+
+			sync_rto_returns(self.so_data, client=self.client)
+
+		create_cn.assert_called_once()
+		self.assertEqual(create_cn.call_args[0][0], "INV-001")
+
+	def test_skips_when_no_invoice_found(self):
+		"""Log and skip the return when the original invoice doesn't exist."""
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch("frappe.db.get_value", return_value=None),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+			patch(f"{CANCELLATION_MODULE}.create_credit_note") as create_cn,
+		):
+			sync_rto_returns(self.so_data, client=self.client)
+
+		log.assert_called_once()
+		self.assertEqual(log.call_args.kwargs["status"], "Invalid")
+		create_cn.assert_not_called()
+
+	def test_filters_non_rto_returns(self):
+		"""Only "Courier Returned" is an RTO; other return types are left alone."""
+		so_data = {
+			"code": "SO-MIXED-001",
+			"returns": [
+				{"code": "RET-001", "type": "Customer Returned"},
+				{"code": "RET-002", "type": "Some Other Type"},
+				{"code": "PKG-RTO", "type": "Courier Returned"},
+			],
+		}
+
+		checked_packages = []
+
+		def mock_exists(doctype, filters=None, *args, **kwargs):
+			checked_packages.append(filters.get(SHIPPING_PACKAGE_CODE_FIELD))
+			return False
+
+		with (
+			patch("frappe.db.exists", side_effect=mock_exists),
+			patch("frappe.db.get_value", return_value=None),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log"),
+		):
+			sync_rto_returns(so_data, client=self.client)
+
+		self.assertEqual(checked_packages, ["PKG-RTO"])
+
+	def test_error_isolation_continues_to_next_package(self):
+		"""One failing package must not skip the rest, eg. a closed accounting period."""
+		so_data = {
+			"code": "SO-MULTI-RTO",
+			"returns": [
+				{"code": "PKG-A", "type": "Courier Returned"},
+				{"code": "PKG-B", "type": "Courier Returned"},
+			],
+		}
+
+		attempted = []
+
+		def mock_create_credit_note(invoice_name, posting_date=None):
+			attempted.append(invoice_name)
+			raise frappe.ValidationError("Accounting period is closed")
+
+		mock_client = MagicMock()
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(
+				"frappe.db.get_value",
+				return_value=frappe._dict(
+					name="INV-001",
+					posting_date="2024-08-01",
+					unicommerce_facility_code="Test-123",
+				),
+			),
+			patch(f"{CANCELLATION_MODULE}.create_credit_note", side_effect=mock_create_credit_note),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+			patch(f"{CANCELLATION_MODULE}.get_return_date_from_package", return_value=(1627900000000, {})),
+		):
+			sync_rto_returns(so_data, client=mock_client)
+
+		# both attempted despite the first raising
+		self.assertEqual(len(attempted), 2)
+		self.assertEqual(log.call_count, 2)
+
+
+class TestCustomerInitiatedReturnSync(TestCase):
+	"""Test customer-initiated return credit note creation."""
+
+	def setUp(self):
+		super().setUp()
+		self.so_data = self.load_fixture("order-with-customer-return")
+		self.client = MagicMock()
+
+	def test_skips_when_credit_note_already_exists(self):
+		"""De-duplication: skip if a credit note with this return code exists."""
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(self.so_data, client=self.client)
+
+		create_cn.assert_not_called()
+
+	def test_creates_credit_note_when_none_exists(self):
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(self.so_data, client=self.client)
+
+		create_cn.assert_called_once()
+
+	def test_returns_early_for_empty_returns(self):
+		"""No-op when the order has no returns."""
+		with patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn:
+			sync_customer_initiated_returns({"code": "SO-NO-RETURNS", "returns": []}, client=self.client)
+
+		create_cn.assert_not_called()
+
+	def test_filters_non_customer_returns(self):
+		"""Only "Customer Returned" is handled here; RTO is a separate path."""
+		so_data = {
+			"code": "SO-MIXED-001",
+			"returns": [
+				{"code": "RET-001", "type": "Courier Returned"},
+				{"code": "RET-002", "type": "Customer Returned"},
+			],
+		}
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note") as create_cn,
+		):
+			sync_customer_initiated_returns(so_data, client=self.client)
+
+		create_cn.assert_called_once()
+
+	def test_error_isolation_continues_to_next_return(self):
+		"""One failing return must not skip the rest of the order's returns."""
+		so_data = {
+			"code": "SO-MULTI-CIR",
+			"returns": [
+				{"code": "RET-A", "type": "Customer Returned"},
+				{"code": "RET-B", "type": "Customer Returned"},
+			],
+		}
+
+		attempted = []
+
+		def mock_create(so_data, return_data, client=None):
+			attempted.append(return_data["code"])
+			raise frappe.ValidationError("Accounting period is closed")
+
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch(f"{CANCELLATION_MODULE}.create_cir_credit_note", side_effect=mock_create),
+			patch(f"{CANCELLATION_MODULE}.create_unicommerce_log") as log,
+		):
+			sync_customer_initiated_returns(so_data, client=self.client)
+
+		self.assertEqual(attempted, ["RET-A", "RET-B"])
+		self.assertEqual(log.call_count, 2)
+
+
+class TestInvoiceForReturnSelection(TestCase):
+	"""Test _get_invoice_for_return finds the right invoice for multi-package orders."""
+
+	@staticmethod
+	def _mock_get_all(invoices, invoice_item_map):
+		"""Stub frappe.get_all for the two queries _get_invoice_for_return makes."""
+
+		def mock_get_all(doctype, **kwargs):
+			if doctype == "Sales Invoice":
+				return invoices
+			if doctype == "Sales Invoice Item":
+				parents = kwargs["filters"]["parent"][1]
+				return [item for parent in parents for item in invoice_item_map.get(parent, [])]
+			return []
+
+		return mock_get_all
+
+	def test_returns_none_when_no_invoices(self):
+		with patch("frappe.get_all", return_value=[]):
+			self.assertIsNone(_get_invoice_for_return("SO-NO-INV", {"A"}))
+
+	def test_returns_single_invoice_without_checking_items(self):
+		"""With one invoice there's nothing to choose between, so skip the item query."""
+		with patch("frappe.get_all", return_value=["INV-001"]) as get_all:
+			self.assertEqual(_get_invoice_for_return("SO-001", {"A"}), "INV-001")
+
+		self.assertEqual(get_all.call_count, 1)
+
+	def test_finds_invoice_containing_returned_items(self):
+		invoices = ["INV-001", "INV-002", "INV-003"]
+		invoice_item_map = {
+			"INV-001": [{"parent": "INV-001", "so_detail": "A"}, {"parent": "INV-001", "so_detail": "B"}],
+			"INV-002": [{"parent": "INV-002", "so_detail": "C"}, {"parent": "INV-002", "so_detail": "D"}],
+			"INV-003": [{"parent": "INV-003", "so_detail": "E"}, {"parent": "INV-003", "so_detail": "F"}],
+		}
+
+		with patch("frappe.get_all", side_effect=self._mock_get_all(invoices, invoice_item_map)):
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"A", "B"}), "INV-001")
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"C", "D"}), "INV-002")
+			# a subset of one invoice's rows still resolves to that invoice
+			self.assertEqual(_get_invoice_for_return("SO-MULTI", {"E"}), "INV-003")
+
+	def test_returns_none_when_items_spread_across_invoices(self):
+		"""No single invoice covers the return, so there's nothing safe to return against."""
+		invoices = ["INV-001", "INV-002"]
+		invoice_item_map = {
+			"INV-001": [{"parent": "INV-001", "so_detail": "A"}],
+			"INV-002": [{"parent": "INV-002", "so_detail": "B"}],
+		}
+
+		with patch("frappe.get_all", side_effect=self._mock_get_all(invoices, invoice_item_map)):
+			self.assertIsNone(_get_invoice_for_return("SO-MULTI", {"A", "B"}))
+
+
+class TestPartialReturns(TestCase):
+	"""Test _handle_partial_returns strips items and rescales tax."""
+
+	@staticmethod
+	def _credit_note(items, item_wise_tax_detail=None, tax_amount=100.0):
+		from types import SimpleNamespace
+
+		tax = SimpleNamespace(tax_amount=tax_amount)
+		if item_wise_tax_detail is not None:
+			tax.item_wise_tax_detail = json.dumps(item_wise_tax_detail)
+
+		return SimpleNamespace(
+			items=[SimpleNamespace(**item) for item in items],
+			taxes=[tax],
+		)
+
+	def test_strips_non_returned_items_and_rescales_tax(self):
+		from types import SimpleNamespace
+
+		credit_note = self._credit_note(
+			items=[
+				{"item_code": "ITEM-A", "qty": 2.0, "sales_invoice_item": "SI-A"},
+				{"item_code": "ITEM-B", "qty": 2.0, "sales_invoice_item": "SI-B"},
+			],
+			item_wise_tax_detail={"ITEM-A": [18.0, 36.0], "ITEM-B": [18.0, 36.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		self.assertEqual([item.item_code for item in credit_note.items], ["ITEM-A"])
+		# ITEM-A fully returned keeps its tax, ITEM-B is zeroed
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 36.0)
+
+	def test_scales_tax_by_returned_quantity(self):
+		"""Returning half the qty of an item credits half its tax."""
+		credit_note = self._credit_note(
+			items=[
+				{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A1"},
+				{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A2"},
+			],
+			item_wise_tax_detail={"ITEM-A": [18.0, 36.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A1"])
+
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 18.0)
+
+	def test_survives_tax_detail_naming_an_absent_item(self):
+		"""The breakup can name an item that isn't on the credit note."""
+		credit_note = self._credit_note(
+			items=[{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A"}],
+			item_wise_tax_detail={"ITEM-A": [18.0, 18.0], "ITEM-GHOST": [18.0, 18.0]},
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		# only the item on the document contributes tax
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 18.0)
+
+	def test_division_by_zero_protection(self):
+		"""Prevent crash when tax breakup references items absent from credit note."""
+		credit_note = self._credit_note(
+			items=[{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A"}],
+			item_wise_tax_detail={"ITEM-B": [18.0, 18.0]},  # ITEM-B not in credit note
+		)
+
+		# Should not raise division by zero
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		# Tax should be zero since no matching items
+		self.assertAlmostEqual(credit_note.taxes[0].tax_amount, 0.0)
+
+	def test_skips_tax_rows_without_item_wise_detail(self):
+		"""Tax rows without an item wise breakup are left alone."""
+		credit_note = self._credit_note(
+			items=[{"item_code": "ITEM-A", "qty": 1.0, "sales_invoice_item": "SI-A"}],
+			item_wise_tax_detail=None,
+			tax_amount=50.0,
+		)
+
+		_handle_partial_returns(credit_note, ["SI-A"])
+
+		self.assertEqual(credit_note.taxes[0].tax_amount, 50.0)
+
+
+class TestReturnAPIIntegration(TestCase):
+	"""Test Return API integration for accurate return dates."""
+
+	def test_get_return_details_from_client(self):
+		"""Test that client.get_return_details method is called correctly."""
+		mock_client = MagicMock()
+		return_details = {
+			"returnSaleOrderValue": {"returnCreatedDate": "2024-08-14 10:30:00", "code": "RET-001"}
+		}
+		mock_client.get_return_details.return_value = return_details
+
+		timestamp, details = get_return_date_from_package(
+			client=mock_client, shipment_code="PKG-001", facility_code="Test-123"
+		)
+
+		self.assertIsNotNone(timestamp)
+		self.assertIsNotNone(details)
+		mock_client.get_return_details.assert_called_once_with(
+			reverse_pickup_code=None, shipment_code="PKG-001", facility_code="Test-123"
+		)
+
+	def test_handles_return_api_failure_gracefully(self):
+		"""Test that Return API failures don't crash the system."""
+		mock_client = MagicMock()
+		mock_client.get_return_details.return_value = None
+
+		timestamp, details = get_return_date_from_package(
+			client=mock_client, shipment_code="PKG-001", facility_code="Test-123"
+		)
+
+		self.assertIsNone(timestamp)
+		self.assertIsNone(details)
+
+	def test_parses_return_date_correctly(self):
+		"""Test that return date string is parsed to timestamp correctly."""
+		mock_client = MagicMock()
+		return_details = {"returnSaleOrderValue": {"returnCreatedDate": "2024-08-14 10:30:00"}}
+		mock_client.get_return_details.return_value = return_details
+
+		timestamp, details = get_return_date_from_package(
+			client=mock_client, shipment_code="PKG-001", facility_code="Test-123"
+		)
+
+		# Should be a valid timestamp (milliseconds)
+		self.assertIsInstance(timestamp, int)
+		self.assertGreater(timestamp, 1700000000000)  # Sometime after 2023


### PR DESCRIPTION

Ticket Ref: [#74405](https://support.frappe.io/helpdesk/tickets/74405?view=VIEW-HD+Ticket-1533)

## Description
 Implements credit note backfill functionality for Unicommerce v15 with proper invoice selection, multi-package support, error isolation, and historical return synchronization.

## Issues Fixed

* **Wrong invoice selected** - Added `is_return: 0` and `docstatus: 1` filters
* **Multi-package returns fail** - Added `_get_invoice_for_return()` method
* **No error isolation** - Added try/except for individual returns
* **Old returns not synced** - Added `_sync_old_returns()` function
* **Division by zero** - Added `original_qty` check before division
* **Database performance** - Optimized duplicate queries

## Changes

* **Invoice selection guards and multi-package matching**
* **Error isolation and Return API integration**
* **Historical return synchronization**
* **Performance optimization**
* **Comprehensive test coverage**