### PR TITLE
fix(shopify): build item-wise tax details so GST orders sync on ERPNext v15+

### DIFF
--- a/ecommerce_integrations/shopify/fulfillment.py
+++ b/ecommerce_integrations/shopify/fulfillment.py
@@ -12,6 +12,7 @@ from ecommerce_integrations.shopify.constants import (
 )
 from ecommerce_integrations.shopify.order import get_sales_order
 from ecommerce_integrations.shopify.utils import create_shopify_log
+from ecommerce_integrations.utils.taxation import copy_item_wise_tax_details
 
 
 def prepare_delivery_note(payload, request_id=None):
@@ -52,6 +53,7 @@ def create_delivery_note(shopify_order, setting, so):
 				dn.items, fulfillment.get("line_items"), fulfillment.get("location_id")
 			)
 			dn.flags.ignore_mandatory = True
+			copy_item_wise_tax_details(dn, so.name)
 			dn.save()
 			dn.submit()
 

--- a/ecommerce_integrations/shopify/invoice.py
+++ b/ecommerce_integrations/shopify/invoice.py
@@ -8,6 +8,7 @@ from ecommerce_integrations.shopify.constants import (
 	SETTING_DOCTYPE,
 )
 from ecommerce_integrations.shopify.utils import create_shopify_log
+from ecommerce_integrations.utils.taxation import copy_item_wise_tax_details
 
 
 def prepare_sales_invoice(payload, request_id=None):
@@ -48,6 +49,7 @@ def create_sales_invoice(shopify_order, setting, so):
 		sales_invoice.naming_series = setting.sales_invoice_series or "SI-Shopify-"
 		sales_invoice.flags.ignore_mandatory = True
 		set_cost_center(sales_invoice.items, setting.cost_center)
+		copy_item_wise_tax_details(sales_invoice, so.name)
 		sales_invoice.insert(ignore_mandatory=True)
 		sales_invoice.submit()
 		if sales_invoice.grand_total > 0:

--- a/ecommerce_integrations/shopify/order.py
+++ b/ecommerce_integrations/shopify/order.py
@@ -21,7 +21,11 @@ from ecommerce_integrations.shopify.customer import ShopifyCustomer
 from ecommerce_integrations.shopify.product import create_items_if_not_exist, get_item_code
 from ecommerce_integrations.shopify.utils import create_shopify_log
 from ecommerce_integrations.utils.price_list import get_dummy_price_list
-from ecommerce_integrations.utils.taxation import get_dummy_tax_category
+from ecommerce_integrations.utils.taxation import (
+	ITEM_WISE_TAX_KEY,
+	get_dummy_tax_category,
+	set_item_wise_tax_details,
+)
 
 DEFAULT_TAX_FIELDS = {
 	"sales_tax": "default_sales_tax_account",
@@ -124,6 +128,7 @@ def create_sales_order(shopify_order, setting, company=None):
 			so.update({"company": company, "status": "Draft"})
 		so.flags.ignore_mandatory = True
 		so.flags.shopiy_order_json = json.dumps(shopify_order)
+		set_item_wise_tax_details(so)
 		so.save(ignore_permissions=True)
 		so.submit()
 
@@ -215,7 +220,7 @@ def get_order_taxes(shopify_order, setting, items):
 					"tax_amount": tax.get("price"),
 					"included_in_print_rate": 0,
 					"cost_center": setting.cost_center,
-					"item_wise_tax_detail": {item_code: [flt(tax.get("rate")) * 100, flt(tax.get("price"))]},
+					ITEM_WISE_TAX_KEY: {item_code: [flt(tax.get("rate")) * 100, flt(tax.get("price"))]},
 					"dont_recompute_tax": 1,
 				}
 			)
@@ -230,11 +235,6 @@ def get_order_taxes(shopify_order, setting, items):
 
 	if cint(setting.consolidate_taxes):
 		taxes = consolidate_order_taxes(taxes)
-
-	for row in taxes:
-		tax_detail = row.get("item_wise_tax_detail")
-		if isinstance(tax_detail, dict):
-			row["item_wise_tax_detail"] = json.dumps(tax_detail)
 
 	return taxes
 
@@ -253,12 +253,12 @@ def consolidate_order_taxes(taxes):
 				"included_in_print_rate": 0,
 				"dont_recompute_tax": 1,
 				"tax_amount": 0,
-				"item_wise_tax_detail": {},
+				ITEM_WISE_TAX_KEY: {},
 			},
 		)
 		tax_account_wise_data[account_head]["tax_amount"] += flt(tax.get("tax_amount"))
-		if tax.get("item_wise_tax_detail"):
-			tax_account_wise_data[account_head]["item_wise_tax_detail"].update(tax["item_wise_tax_detail"])
+		if tax.get(ITEM_WISE_TAX_KEY):
+			tax_account_wise_data[account_head][ITEM_WISE_TAX_KEY].update(tax[ITEM_WISE_TAX_KEY])
 
 	return tax_account_wise_data.values()
 
@@ -343,7 +343,7 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, setting, items, taxe
 					),
 					"tax_amount": tax["price"],
 					"cost_center": setting.cost_center,
-					"item_wise_tax_detail": {
+					ITEM_WISE_TAX_KEY: {
 						setting.shipping_item: [flt(tax.get("rate")) * 100, flt(tax.get("price"))]
 					}
 					if shipping_as_item

--- a/ecommerce_integrations/shopify/tests/test_order.py
+++ b/ecommerce_integrations/shopify/tests/test_order.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from ecommerce_integrations.shopify.order import get_order_items
+from ecommerce_integrations.utils.taxation import ITEM_WISE_TAX_KEY, set_item_wise_tax_details
 
 
 class TestOrder(IntegrationTestCase):
@@ -42,3 +43,48 @@ class TestOrder(IntegrationTestCase):
 		self.assertEqual(items[0]["is_free_item"], 1)
 		self.assertEqual(items[1]["rate"], 9.0)
 		self.assertEqual(items[1]["is_free_item"], 0)
+
+	def test_set_item_wise_tax_details_builds_item_wise_details(self):
+		# dont_recompute rows must seed the item-wise breakup, else IC rejects the order.
+		if not frappe.get_meta("Sales Order").get_field("item_wise_tax_details"):
+			self.skipTest("ERPNext without item_wise_tax_details table")
+
+		so = frappe.new_doc("Sales Order")
+		so.append("items", {"item_code": "SHOPIFY-A", "qty": 1, "rate": 100})
+		so.append("items", {"item_code": "SHOPIFY-B", "qty": 2, "rate": 50})
+		so.append(
+			"taxes",
+			{
+				"charge_type": "Actual",
+				"account_head": "CGST",
+				"tax_amount": 18,
+				"dont_recompute_tax": 1,
+				ITEM_WISE_TAX_KEY: {"SHOPIFY-A": [9, 9], "SHOPIFY-B": [9, 9]},
+			},
+		)
+
+		set_item_wise_tax_details(so)
+
+		rows = so.get("_item_wise_tax_details")
+		self.assertEqual(len(rows), 2)
+		by_item = {row.item.item_code: row for row in rows}
+		self.assertEqual(by_item["SHOPIFY-A"].rate, 9)
+		self.assertEqual(by_item["SHOPIFY-A"].amount, 9)
+		self.assertEqual(by_item["SHOPIFY-A"].taxable_amount, 100)
+		self.assertEqual(by_item["SHOPIFY-B"].taxable_amount, 100)
+
+	def test_set_item_wise_tax_details_skips_rows_without_item_wise_tax(self):
+		# Rows without per-item data (e.g. shipping without an item) produce no rows.
+		if not frappe.get_meta("Sales Order").get_field("item_wise_tax_details"):
+			self.skipTest("ERPNext without item_wise_tax_details table")
+
+		so = frappe.new_doc("Sales Order")
+		so.append("items", {"item_code": "SHOPIFY-A", "qty": 1, "rate": 100})
+		so.append(
+			"taxes",
+			{"charge_type": "Actual", "account_head": "Shipping", "tax_amount": 50, "dont_recompute_tax": 1},
+		)
+
+		set_item_wise_tax_details(so)
+
+		self.assertFalse(so.get("_item_wise_tax_details"))

--- a/ecommerce_integrations/utils/taxation.py
+++ b/ecommerce_integrations/utils/taxation.py
@@ -1,7 +1,13 @@
+from collections import defaultdict, deque
+
 import frappe
 from frappe import _
+from frappe.utils import flt
 
 DUMMY_TAX_CATEGORY = "Ecommerce Integrations - Ignore"
+
+# Internal per-tax-row carrier for {item_code: [rate, amount]}.
+ITEM_WISE_TAX_KEY = "_item_wise_tax"
 
 
 def get_dummy_tax_category() -> str:
@@ -12,6 +18,71 @@ def get_dummy_tax_category() -> str:
 	if not frappe.db.exists("Tax Category", DUMMY_TAX_CATEGORY):
 		frappe.get_doc(doctype="Tax Category", title=DUMMY_TAX_CATEGORY).insert()
 	return DUMMY_TAX_CATEGORY
+
+
+def set_item_wise_tax_details(doc):
+	"""Seed `_item_wise_tax_details` for our dont_recompute rows (ERPNext v15+ won't build it)."""
+
+	if not doc.meta.get_field("item_wise_tax_details"):
+		return
+
+	items_by_code = {}
+	for item in doc.get("items"):
+		items_by_code.setdefault(item.item_code, item)
+
+	rows = []
+	for tax in doc.get("taxes"):
+		for item_code, (rate, amount) in (tax.get(ITEM_WISE_TAX_KEY) or {}).items():
+			item = items_by_code.get(item_code)
+			if not item:
+				continue
+
+			rows.append(
+				frappe._dict(
+					item=item,
+					tax=tax,
+					rate=flt(rate),
+					amount=flt(amount),
+					taxable_amount=flt(item.get("net_amount")) or flt(item.qty) * flt(item.rate),
+				)
+			)
+
+	if rows:
+		doc._item_wise_tax_details = rows
+
+
+def copy_item_wise_tax_details(target, source_name):
+	"""Rebuild item-wise tax on a doc mapped from a Sales Order (SI/DN); the SO->SI mapper drops it."""
+
+	if not target.meta.get_field("item_wise_tax_details"):
+		return
+
+	source = frappe.get_doc("Sales Order", source_name)
+	item_code_by_row = {row.name: row.item_code for row in source.items}
+
+	# {source tax row -> {item_code: [rate, amount]}}, keeping each row's own breakup
+	detail_by_tax_row = {}
+	for row in source.get("item_wise_tax_details") or []:
+		item_code = item_code_by_row.get(row.item_row)
+		if item_code:
+			detail_by_tax_row.setdefault(row.tax_row, {})[item_code] = [row.rate, row.amount]
+
+	if not detail_by_tax_row:
+		return
+
+	# Source rows carrying a breakup, queued per account in order; the mapper preserves
+	# order, so the k-th target row of an account maps to the k-th source row.
+	source_details = defaultdict(deque)
+	for tax in source.taxes:
+		if tax.name in detail_by_tax_row:
+			source_details[tax.account_head].append(detail_by_tax_row[tax.name])
+
+	for tax in target.get("taxes"):
+		queue = source_details.get(tax.account_head)
+		if queue:
+			tax.set(ITEM_WISE_TAX_KEY, queue.popleft())
+
+	set_item_wise_tax_details(target)
 
 
 def validate_tax_template(doc, method=None):


### PR DESCRIPTION
### Issue

Shopify orders that contain any taxable (GST) line item fail to sync on ERPNext v15+, throwing India Compliance's **"No GST is being charged on Taxable Items"**. Only zero-tax orders sync through.

https://support.frappe.io/helpdesk/tickets/76925?view=VIEW-HD+Ticket-70177

### Root cause (India Compliance interaction)

The connector books the exact Shopify tax as `Actual` / `dont_recompute_tax` rows and records the per-item breakup in the legacy `item_wise_tax_detail` JSON field.

ERPNext v16 moved item-wise tax out of that field into the `item_wise_tax_details` table (in-memory `_item_wise_tax_details`) and no longer reads the old field. For `dont_recompute_tax` rows ERPNext only *retains* this structure — it never builds it — so item-level GST stays `0`. India Compliance then rejects the order because a taxable item shows a `0` GST rate.

### Fix (Sales Order → Sales Invoice → Delivery Note)

- Build `_item_wise_tax_details` on the synced **Sales Order** from the per-item taxes we already compute (`set_item_wise_tax_details`), and drop the now-dead write to the `item_wise_tax_detail` JSON field.
- The **SO → Sales Invoice** mapper doesn't carry the item-wise breakup (child-row names change on mapping, and unlike the Delivery Note / Purchase mappers it doesn't call `merge_taxes`). So paid orders would fail next at the invoice, and fulfilled orders at the delivery note. `copy_item_wise_tax_details` rebuilds the breakup on those mapped docs from the source order, matched by **item code + tax account** (robust to remapped row names).
- Gated on the `item_wise_tax_details` field existing → no-op on older ERPNext.

Verified end-to-end (Sales Order, Sales Invoice, Delivery Note) on a GST company with India Compliance installed; added regression tests for the seeding.
